### PR TITLE
Extended build support

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -33,7 +33,7 @@ jobs:
         echo "AIKIDO_ARTIFACT=aikido-$AIKIDO_VERSION-php-${{ matrix.php_version }}" >> $GITHUB_ENV
 
     - name: Setup PHP
-      uses: AikidoSec/setup-php@2
+      uses: AikidoSec/setup-php@v2
       with:
         php-version: ${{ matrix.php_version }}
         extensions: :curl


### PR DESCRIPTION
- Added support for building, testing and generating artifacts for PHP versions from 7.3 to 8.4
- Get aikido version from php_aikido.h and use it to version artifacts
- Use setup-php github action to reduce build & testing to ~1 minute per version
- Store test failures in case of failure for debugging 