### PR TITLE
Discover route support

### DIFF
--- a/include/Utils.h
+++ b/include/Utils.h
@@ -67,6 +67,7 @@ enum ACTION {
 	EXIT
 };
 
-ACTION send_request_metadata_event();
+ACTION send_request_init_metadata_event();
+ACTION send_request_shutdown_metadata_event();
 
 ACTION aikido_execute_output(json event);

--- a/lib/agent/grpc/request.go
+++ b/lib/agent/grpc/request.go
@@ -14,7 +14,7 @@ func storeStats() {
 	globals.StatsData.Requests += 1
 }
 
-func storeRoute(req *protos.RequestMetadata) {
+func storeRoute(req *protos.RequestMetadataShutdown) {
 	globals.RoutesMutex.Lock()
 	defer globals.RoutesMutex.Unlock()
 
@@ -27,7 +27,7 @@ func storeRoute(req *protos.RequestMetadata) {
 	globals.Routes[req.GetMethod()][req.GetRoute()]++
 }
 
-func updateRateLimitingStatus(req *protos.RequestMetadata) {
+func updateRateLimitingStatus(req *protos.RequestMetadataShutdown) {
 	globals.RateLimitingMutex.Lock()
 	defer globals.RateLimitingMutex.Unlock()
 
@@ -40,7 +40,7 @@ func updateRateLimitingStatus(req *protos.RequestMetadata) {
 	rateLimitingData.Status.NumberOfRequestsPerWindow.IncrementLast()
 }
 
-func getRequestStatus(req *protos.RequestMetadata) *protos.RequestStatus {
+func getRequestStatus(req *protos.RequestMetadataInit) *protos.RequestStatus {
 	globals.RateLimitingMutex.Lock()
 	defer globals.RateLimitingMutex.Unlock()
 

--- a/lib/agent/grpc/server.go
+++ b/lib/agent/grpc/server.go
@@ -23,14 +23,21 @@ func (s *server) OnDomain(ctx context.Context, req *protos.Domain) (*emptypb.Emp
 	return &emptypb.Empty{}, nil
 }
 
-func (s *server) OnRequest(ctx context.Context, req *protos.RequestMetadata) (*protos.RequestStatus, error) {
+func (s *server) OnRequestInit(ctx context.Context, req *protos.RequestMetadataInit) (*protos.RequestStatus, error) {
 	log.Debugf("Received request metadata: %s %s", req.GetMethod(), req.GetRoute())
 
 	go storeStats()
+
+	return getRequestStatus(req), nil
+}
+
+func (s *server) OnRequestShutdown(ctx context.Context, req *protos.RequestMetadataShutdown) (*emptypb.Empty, error) {
+	log.Debugf("Received request metadata: %s %s %d", req.GetMethod(), req.GetRoute(), req.GetStatusCode())
+
 	go storeRoute(req)
 	go updateRateLimitingStatus(req)
 
-	return getRequestStatus(req), nil
+	return &emptypb.Empty{}, nil
 }
 
 func (s *server) GetCloudConfig(ctx context.Context, req *emptypb.Empty) (*protos.CloudConfig, error) {

--- a/lib/ipc.proto
+++ b/lib/ipc.proto
@@ -8,7 +8,8 @@ option go_package = "ipc/protos;protos";
 
 service Aikido {
   rpc OnDomain (Domain) returns (google.protobuf.Empty);
-  rpc OnRequest (RequestMetadata) returns (RequestStatus);
+  rpc OnRequestInit (RequestMetadataInit) returns (RequestStatus);
+  rpc OnRequestShutdown (RequestMetadataShutdown) returns (google.protobuf.Empty);
   rpc GetCloudConfig(google.protobuf.Empty) returns (CloudConfig);
 }
 
@@ -16,10 +17,17 @@ message Domain {
   string domain = 1;
 }
 
-message RequestMetadata {
+message RequestMetadataInit {
   string method = 1;
   string route = 2;
 }
+
+message RequestMetadataShutdown {
+  string method = 1;
+  string route = 2;
+  int32 statusCode = 3;
+}
+
 
 message RateLimiting {
   bool enabled = 1;

--- a/lib/php-extension/Aikido.cpp
+++ b/lib/php-extension/Aikido.cpp
@@ -205,7 +205,7 @@ PHP_RINIT_FUNCTION(aikido) {
 		/* Guarantee that "_SERVER" global variable is initialized for the current request */
 		zend_is_auto_global(server_str); 
 		zend_string_release(server_str);
-		if (send_request_metadata_event() == EXIT) {
+		if (send_request_init_metadata_event() == EXIT) {
 			#if PHP_VERSION_ID < 80000
 				AIKIDO_LOG_INFO("Marking current request for exit!\n");
 				exit_current_request = true;
@@ -236,6 +236,8 @@ PHP_RSHUTDOWN_FUNCTION(aikido) {
 		}
 	}
 	*/
+
+	send_request_shutdown_metadata_event();
 
 	AIKIDO_LOG_DEBUG("RSHUTDOWN finished!\n");
 	return SUCCESS;

--- a/lib/request-processor/main.go
+++ b/lib/request-processor/main.go
@@ -14,7 +14,8 @@ import (
 var eventHandlers = map[string]HandlerFunction{
 	"function_executed": OnFunctionExecuted,
 	"method_executed":   OnMethodExecuted,
-	"request_metadata":  OnRequestMetadata,
+	"request_init":      OnRequestInit,
+	"request_shutdown":  OnRequestShutdown,
 }
 
 //export RequestProcessorInit

--- a/lib/request-processor/utils/should_discover_route.go
+++ b/lib/request-processor/utils/should_discover_route.go
@@ -1,0 +1,123 @@
+package utils
+
+import (
+	"path/filepath"
+	"strings"
+)
+
+const (
+	NOT_FOUND          = 404
+	METHOD_NOT_ALLOWED = 405
+	MOVED_PERMANENTLY  = 301
+	FOUND              = 302
+	SEE_OTHER          = 303
+	TEMPORARY_REDIRECT = 307
+	PERMANENT_REDIRECT = 308
+)
+
+var ERROR_CODES = []int{NOT_FOUND, METHOD_NOT_ALLOWED}
+var REDIRECT_CODES = []int{
+	MOVED_PERMANENTLY,
+	FOUND,
+	SEE_OTHER,
+	TEMPORARY_REDIRECT,
+	PERMANENT_REDIRECT,
+}
+var EXCLUDED_METHODS = []string{"OPTIONS", "HEAD"}
+var IGNORE_EXTENSIONS = []string{"properties", "asp", "aspx", "jsp", "config"}
+var ALLOW_EXTENSIONS = []string{"html", "php"}
+var IGNORE_STRINGS = []string{"cgi-bin"}
+
+func ShouldDiscoverRoute(statusCode int, route, method string) bool {
+	if containsStr(EXCLUDED_METHODS, method) {
+		return false
+	}
+
+	if containsInt(ERROR_CODES, statusCode) {
+		return false
+	}
+
+	if containsInt(REDIRECT_CODES, statusCode) {
+		return false
+	}
+
+	segments := strings.Split(route, "/")
+
+	// e.g. /path/to/.file or /.directory/file
+	for _, segment := range segments {
+		if isDotFile(segment) {
+			return false
+		}
+	}
+
+	for _, segment := range segments {
+		if containsIgnoredString(segment) {
+			return false
+		}
+	}
+
+	for _, segment := range segments {
+		if !isAllowedExtension(segment) {
+			return false
+		}
+	}
+
+	return true
+}
+
+func isAllowedExtension(segment string) bool {
+	extension := filepath.Ext(segment)
+
+	if extension != "" && strings.HasPrefix(extension, ".") {
+		extension = extension[1:]
+
+		if containsStr(ALLOW_EXTENSIONS, extension) {
+			return true
+		}
+
+		if len(extension) >= 2 && len(extension) <= 5 {
+			return false
+		}
+
+		if containsStr(IGNORE_EXTENSIONS, extension) {
+			return false
+		}
+	}
+
+	return true
+}
+
+func isDotFile(segment string) bool {
+	if segment == ".well-known" {
+		return false
+	}
+
+	return strings.HasPrefix(segment, ".") && len(segment) > 1
+}
+
+func containsIgnoredString(segment string) bool {
+	for _, str := range IGNORE_STRINGS {
+		if strings.Contains(segment, str) {
+			return true
+		}
+	}
+	return false
+}
+
+func containsInt(slice []int, item int) bool {
+	for _, s := range slice {
+		if s == item {
+			return true
+		}
+	}
+	return false
+}
+
+func containsStr(slice []string, item string) bool {
+	for _, s := range slice {
+		if s == item {
+			return true
+		}
+	}
+	return false
+}

--- a/lib/request-processor/utils/should_discover_route_test.go
+++ b/lib/request-processor/utils/should_discover_route_test.go
@@ -1,0 +1,187 @@
+package utils
+
+import (
+	"testing"
+)
+
+func TestShouldDiscoverRoute(t *testing.T) {
+	t.Run("it does not discover route if not found or method not allowed", func(t *testing.T) {
+		if ShouldDiscoverRoute(404, "/", "GET") != false {
+			t.Errorf("Expected false, got true")
+		}
+		if ShouldDiscoverRoute(405, "/", "GET") != false {
+			t.Errorf("Expected false, got true")
+		}
+	})
+
+	t.Run("it discovers route for all other status codes", func(t *testing.T) {
+		if ShouldDiscoverRoute(200, "/", "GET") != true {
+			t.Errorf("Expected true, got false")
+		}
+		if ShouldDiscoverRoute(500, "/", "GET") != true {
+			t.Errorf("Expected true, got false")
+		}
+		if ShouldDiscoverRoute(400, "/", "GET") != true {
+			t.Errorf("Expected true, got false")
+		}
+		if ShouldDiscoverRoute(300, "/", "GET") != true {
+			t.Errorf("Expected true, got false")
+		}
+		if ShouldDiscoverRoute(201, "/", "GET") != true {
+			t.Errorf("Expected true, got false")
+		}
+	})
+
+	t.Run("it does not discover route for OPTIONS or HEAD methods", func(t *testing.T) {
+		if ShouldDiscoverRoute(200, "/", "OPTIONS") != false {
+			t.Errorf("Expected false, got true")
+		}
+		if ShouldDiscoverRoute(200, "/", "HEAD") != false {
+			t.Errorf("Expected false, got true")
+		}
+	})
+
+	t.Run("it does not discover route for OPTIONS or HEAD methods even with other status codes", func(t *testing.T) {
+		if ShouldDiscoverRoute(404, "/", "OPTIONS") != false {
+			t.Errorf("Expected false, got true")
+		}
+		if ShouldDiscoverRoute(405, "/", "HEAD") != false {
+			t.Errorf("Expected false, got true")
+		}
+	})
+
+	t.Run("it does not discover static files", func(t *testing.T) {
+		if ShouldDiscoverRoute(200, "/service-worker.js", "GET") != false {
+			t.Errorf("Expected false, got true")
+		}
+		if ShouldDiscoverRoute(200, "/precache-manifest.10faec0bee24db502c8498078126dd53.js", "POST") != false {
+			t.Errorf("Expected false, got true")
+		}
+		if ShouldDiscoverRoute(200, "/img/icons/favicon-16x16.png", "GET") != false {
+			t.Errorf("Expected false, got true")
+		}
+		if ShouldDiscoverRoute(200, "/fonts/icomoon.ttf", "GET") != false {
+			t.Errorf("Expected false, got true")
+		}
+	})
+
+	t.Run("it allows html and php files", func(t *testing.T) {
+		if ShouldDiscoverRoute(200, "/index.html", "GET") != true {
+			t.Errorf("Expected true, got false")
+		}
+		if ShouldDiscoverRoute(200, "/contact.html", "GET") != true {
+			t.Errorf("Expected true, got false")
+		}
+		if ShouldDiscoverRoute(200, "/index.php", "GET") != true {
+			t.Errorf("Expected true, got false")
+		}
+		if ShouldDiscoverRoute(200, "/contact.php", "GET") != true {
+			t.Errorf("Expected true, got false")
+		}
+	})
+
+	t.Run("it allows files with extension of one character", func(t *testing.T) {
+		if ShouldDiscoverRoute(200, "/a.a", "GET") != true {
+			t.Errorf("Expected true, got false")
+		}
+	})
+
+	t.Run("it allows files with extension of 6 or more characters", func(t *testing.T) {
+		if ShouldDiscoverRoute(200, "/a.aaaaaa", "GET") != true {
+			t.Errorf("Expected true, got false")
+		}
+		if ShouldDiscoverRoute(200, "/a.aaaaaaa", "GET") != true {
+			t.Errorf("Expected true, got false")
+		}
+	})
+
+	t.Run("it ignores files that end with .properties", func(t *testing.T) {
+		if ShouldDiscoverRoute(200, "/file.properties", "GET") != false {
+			t.Errorf("Expected false, got true")
+		}
+		if ShouldDiscoverRoute(200, "/directory/file.properties", "GET") != false {
+			t.Errorf("Expected false, got true")
+		}
+	})
+
+	t.Run("it ignores files or directories that start with dot", func(t *testing.T) {
+		if ShouldDiscoverRoute(200, "/.env", "GET") != false {
+			t.Errorf("Expected false, got true")
+		}
+		if ShouldDiscoverRoute(200, "/.aws/credentials", "GET") != false {
+			t.Errorf("Expected false, got true")
+		}
+		if ShouldDiscoverRoute(200, "/directory/.gitconfig", "GET") != false {
+			t.Errorf("Expected false, got true")
+		}
+		if ShouldDiscoverRoute(200, "/hello/.gitignore/file", "GET") != false {
+			t.Errorf("Expected false, got true")
+		}
+	})
+
+	// t.Run("it ignores files that end with php (used as directory)", func(t *testing.T) {
+	// 	if ShouldDiscoverRoute(200, "/file.php", "GET") != false {
+	// 		t.Errorf("Expected false, got true")
+	// 	}
+	// 	if ShouldDiscoverRoute(200, "/app_dev.php/_profiler/phpinfo", "GET") != false {
+	// 		t.Errorf("Expected false, got true")
+	// 	}
+	// })
+
+	t.Run("it allows .well-known directory", func(t *testing.T) {
+		if ShouldDiscoverRoute(200, "/.well-known", "GET") != true {
+			t.Errorf("Expected true, got false")
+		}
+		if ShouldDiscoverRoute(200, "/.well-known/change-password", "GET") != true {
+			t.Errorf("Expected true, got false")
+		}
+		if ShouldDiscoverRoute(200, "/.well-known/security.txt", "GET") != false {
+			t.Errorf("Expected false, got true")
+		}
+	})
+
+	t.Run("it ignores certain strings", func(t *testing.T) {
+		if ShouldDiscoverRoute(200, "/cgi-bin/luci/;stok=/locale", "GET") != false {
+			t.Errorf("Expected false, got true")
+		}
+		if ShouldDiscoverRoute(200, "/whatever/cgi-bin", "GET") != false {
+			t.Errorf("Expected false, got true")
+		}
+	})
+
+	t.Run("it should ignore fonts", func(t *testing.T) {
+		if ShouldDiscoverRoute(200, "/fonts/icomoon.ttf", "GET") != false {
+			t.Errorf("Expected false, got true")
+		}
+		if ShouldDiscoverRoute(200, "/fonts/icomoon.woff", "GET") != false {
+			t.Errorf("Expected false, got true")
+		}
+		if ShouldDiscoverRoute(200, "/fonts/icomoon.woff2", "GET") != false {
+			t.Errorf("Expected false, got true")
+		}
+	})
+
+	t.Run("it ignores files that end with .config", func(t *testing.T) {
+		if ShouldDiscoverRoute(200, "/blog/App_Config/ConnectionStrings.config", "GET") != false {
+			t.Errorf("Expected false, got true")
+		}
+	})
+
+	t.Run("it ignores redirects", func(t *testing.T) {
+		if ShouldDiscoverRoute(301, "/", "GET") != false {
+			t.Errorf("Expected false, got true")
+		}
+		if ShouldDiscoverRoute(302, "/", "GET") != false {
+			t.Errorf("Expected false, got true")
+		}
+		if ShouldDiscoverRoute(303, "/", "GET") != false {
+			t.Errorf("Expected false, got true")
+		}
+		if ShouldDiscoverRoute(307, "/", "GET") != false {
+			t.Errorf("Expected false, got true")
+		}
+		if ShouldDiscoverRoute(308, "/", "GET") != false {
+			t.Errorf("Expected false, got true")
+		}
+	})
+}


### PR DESCRIPTION
- Send route/method on RINIT via sync gRPC, if they are configured for rate limiting
- Send route/method on RSHUTDOWN via async gRPC, along with status code
- Filter routes that should appear in the interface
- Added tests for the route discovery