### PR TITLE
API spec on by default and caching improvements

### DIFF
--- a/lib/agent/globals/constants.go
+++ b/lib/agent/globals/constants.go
@@ -1,7 +1,7 @@
 package globals
 
 const (
-	Version                            = "1.0.94"
+	Version                            = "1.0.95"
 	ConfigUpdatedAtMethod              = "GET"
 	ConfigUpdatedAtAPI                 = "/config"
 	ConfigAPIMethod                    = "GET"

--- a/lib/php-extension/Environment.cpp
+++ b/lib/php-extension/Environment.cpp
@@ -34,7 +34,7 @@ void LoadEnvironment() {
 
     AIKIDO_GLOBAL(blocking) = GetEnvBool("AIKIDO_BLOCK", false);
     AIKIDO_GLOBAL(disable) = GetEnvBool("AIKIDO_DISABLE", false);
-    AIKIDO_GLOBAL(collect_api_schema) = GetEnvBool("AIKIDO_FEATURE_COLLECT_API_SCHEMA", false);
+    AIKIDO_GLOBAL(collect_api_schema) = GetEnvBool("AIKIDO_FEATURE_COLLECT_API_SCHEMA", true);
     AIKIDO_GLOBAL(localhost_allowed_by_default) = GetEnvBool("AIKIDO_LOCALHOST_ALLOWED_BY_DEFAULT", true);
     AIKIDO_GLOBAL(trust_proxy) = GetEnvBool("AIKIDO_TRUST_PROXY", true);
     AIKIDO_GLOBAL(socket_path) = GenerateSocketPath();

--- a/lib/php-extension/include/php_aikido.h
+++ b/lib/php-extension/include/php_aikido.h
@@ -3,7 +3,7 @@
 extern zend_module_entry aikido_module_entry;
 #define phpext_aikido_ptr &aikido_module_entry
 
-#define PHP_AIKIDO_VERSION "1.0.94"
+#define PHP_AIKIDO_VERSION "1.0.95"
 
 #if defined(ZTS) && defined(COMPILE_DL_AIKIDO)
 ZEND_TSRMLS_CACHE_EXTERN()

--- a/lib/request-processor/aikido_types/handle.go
+++ b/lib/request-processor/aikido_types/handle.go
@@ -6,3 +6,19 @@ type Method struct {
 	ClassName  string
 	MethodName string
 }
+
+type QueryExecuted struct {
+	Query     string
+	Operation string
+	Dialect   string
+}
+
+type FileAccessed struct {
+	Filename  string
+	Operation string
+}
+
+type ShellExecuted struct {
+	Cmd       string
+	Operation string
+}

--- a/lib/request-processor/context/request_context.go
+++ b/lib/request-processor/context/request_context.go
@@ -54,13 +54,16 @@ func Clear() bool {
 	return true
 }
 
-func CheckVulnerabilityOrGetFromCache[T comparable](eventData *T, checkVulnFn func(*T) *utils.InterceptorResult, cache map[T]*utils.InterceptorResult) *utils.InterceptorResult {
-	result, resultWasCached := cache[*eventData]
+func CheckVulnerabilityOrGetFromCache[T comparable](eventData *T, checkVulnFn func(*T) *utils.InterceptorResult, cache *map[T]*utils.InterceptorResult) *utils.InterceptorResult {
+	if *cache == nil {
+		*cache = make(map[T]*utils.InterceptorResult)
+	}
+	result, resultWasCached := (*cache)[*eventData]
 	if resultWasCached {
 		return result
 	}
 	result = checkVulnFn(eventData)
-	cache[*eventData] = result
+	(*cache)[*eventData] = result
 	return result
 }
 

--- a/lib/request-processor/globals/globals.go
+++ b/lib/request-processor/globals/globals.go
@@ -11,5 +11,5 @@ var CloudConfig CloudConfigData
 var CloudConfigMutex sync.Mutex
 
 const (
-	Version = "1.0.94"
+	Version = "1.0.95"
 )

--- a/lib/request-processor/handle_path_traversal.go
+++ b/lib/request-processor/handle_path_traversal.go
@@ -42,7 +42,7 @@ func OnPrePathAccessed() string {
 	for _, f := range []string{filename, filename2} {
 		res := context.CheckVulnerabilityOrGetFromCache(&FileAccessed{Filename: f, Operation: operation},
 			path_traversal.CheckContextForPathTraversal,
-			context.Context.CachedFileAccessedResults)
+			&context.Context.CachedFileAccessedResults)
 		if res != nil {
 			return attack.ReportAttackDetected(res)
 		}

--- a/lib/request-processor/handle_path_traversal.go
+++ b/lib/request-processor/handle_path_traversal.go
@@ -9,22 +9,6 @@ import (
 	path_traversal "main/vulnerabilities/path-traversal"
 )
 
-func CheckOrGetFromCache(fileAccessed *FileAccessed) *utils.InterceptorResult {
-	res, resultWasCached := context.Context.CachedFileAccessedResults[*fileAccessed]
-	if resultWasCached {
-		if res != nil {
-			return res
-		}
-	} else {
-		res = path_traversal.CheckContextForPathTraversal(fileAccessed)
-		context.Context.CachedFileAccessedResults[*fileAccessed] = res
-		if res != nil {
-			return res
-		}
-	}
-	return nil
-}
-
 func OnPrePathAccessed() string {
 	filename := utils.SanitizePath(context.GetFilename())
 	filename2 := utils.SanitizePath(context.GetFilename2())

--- a/lib/request-processor/handle_pdo.go
+++ b/lib/request-processor/handle_pdo.go
@@ -24,7 +24,7 @@ func OnPreSqlQueryExecuted() string {
 
 	res := context.CheckVulnerabilityOrGetFromCache(&QueryExecuted{Query: query, Operation: operation, Dialect: dialect},
 		sql_injection.CheckContextForSqlInjection,
-		context.Context.CachedQueryExecutedResults)
+		&context.Context.CachedQueryExecutedResults)
 	if res != nil {
 		return attack.ReportAttackDetected(res)
 	}

--- a/lib/request-processor/handle_pdo.go
+++ b/lib/request-processor/handle_pdo.go
@@ -1,6 +1,7 @@
 package main
 
 import (
+	. "main/aikido_types"
 	"main/attack"
 	"main/context"
 	"main/log"
@@ -21,7 +22,9 @@ func OnPreSqlQueryExecuted() string {
 		return ""
 	}
 
-	res := sql_injection.CheckContextForSqlInjection(query, operation, dialect)
+	res := context.CheckVulnerabilityOrGetFromCache(&QueryExecuted{Query: query, Operation: operation, Dialect: dialect},
+		sql_injection.CheckContextForSqlInjection,
+		context.Context.CachedQueryExecutedResults)
 	if res != nil {
 		return attack.ReportAttackDetected(res)
 	}

--- a/lib/request-processor/handle_shell_execution.go
+++ b/lib/request-processor/handle_shell_execution.go
@@ -23,7 +23,7 @@ func OnPreShellExecuted() string {
 	}
 	res := context.CheckVulnerabilityOrGetFromCache(&ShellExecuted{Cmd: cmd, Operation: operation},
 		shell_injection.CheckContextForShellInjection,
-		context.Context.CachedShellExecutedResults)
+		&context.Context.CachedShellExecutedResults)
 	if res != nil {
 		return attack.ReportAttackDetected(res)
 	}

--- a/lib/request-processor/handle_shell_execution.go
+++ b/lib/request-processor/handle_shell_execution.go
@@ -1,6 +1,7 @@
 package main
 
 import (
+	. "main/aikido_types"
 	"main/attack"
 	"main/context"
 	"main/log"
@@ -20,8 +21,9 @@ func OnPreShellExecuted() string {
 		log.Infof("Protection is turned off -> will not run detection logic!")
 		return ""
 	}
-
-	res := shell_injection.CheckContextForShellInjection(cmd, operation)
+	res := context.CheckVulnerabilityOrGetFromCache(&ShellExecuted{Cmd: cmd, Operation: operation},
+		shell_injection.CheckContextForShellInjection,
+		context.Context.CachedShellExecutedResults)
 	if res != nil {
 		return attack.ReportAttackDetected(res)
 	}

--- a/lib/request-processor/utils/utils.go
+++ b/lib/request-processor/utils/utils.go
@@ -226,3 +226,11 @@ func ArrayContains(array []string, search string) bool {
 	}
 	return false
 }
+
+func SanitizePath(path string) string {
+	// If path starts with file:// -> remove it
+	if len(path) > 7 && path[:7] == "file://" {
+		path = path[7:]
+	}
+	return path
+}

--- a/lib/request-processor/vulnerabilities/path-traversal/checkContextForPathTraversal.go
+++ b/lib/request-processor/vulnerabilities/path-traversal/checkContextForPathTraversal.go
@@ -1,39 +1,30 @@
 package path_traversal
 
 import (
+	. "main/aikido_types"
 	"main/context"
 	"main/utils"
 )
 
-func CheckContextForPathTraversal(filename string, operation string, checkPathStart bool) *utils.InterceptorResult {
+func CheckContextForPathTraversal(fileAccessed *FileAccessed) *utils.InterceptorResult {
 	for _, source := range context.SOURCES {
 		mapss := source.CacheGet()
-		sanitizedPath := SanitizePath(filename)
 
 		for str, path := range mapss {
-			inputString := SanitizePath(str)
-			if detectPathTraversal(sanitizedPath, inputString, checkPathStart) {
+			inputString := utils.SanitizePath(str)
+			if detectPathTraversal(fileAccessed.Filename, inputString, true) {
 				return &utils.InterceptorResult{
-					Operation:     operation,
+					Operation:     fileAccessed.Operation,
 					Kind:          utils.Path_traversal,
 					Source:        source.Name,
 					PathToPayload: path,
 					Metadata: map[string]string{
-						"filename": filename,
+						"filename": fileAccessed.Filename,
 					},
 					Payload: str,
 				}
 			}
 		}
-
 	}
 	return nil
-}
-
-func SanitizePath(path string) string {
-	// If path starts with file:// -> remove it
-	if len(path) > 7 && path[:7] == "file://" {
-		path = path[7:]
-	}
-	return path
 }

--- a/lib/request-processor/vulnerabilities/path-traversal/checkContextForPathTraversal_test.go
+++ b/lib/request-processor/vulnerabilities/path-traversal/checkContextForPathTraversal_test.go
@@ -1,6 +1,7 @@
 package path_traversal
 
 import (
+	. "main/aikido_types"
 	"main/context"
 	"main/utils"
 	"testing"
@@ -18,7 +19,7 @@ func TestCheckContextForPathTraversal(t *testing.T) {
 		})
 
 		operation := "operation"
-		result := CheckContextForPathTraversal("../file/test.txt", operation, true)
+		result := CheckContextForPathTraversal(&FileAccessed{Filename: "../file/test.txt", Operation: operation})
 
 		if result == nil {
 			t.Errorf("expected result, got nil")
@@ -83,7 +84,7 @@ func TestCheckContextForPathTraversal(t *testing.T) {
 			"remoteAddress": "127.0.0.1",
 		})
 
-		result := CheckContextForPathTraversal("../../web/spec-extension/cookies", operation, true)
+		result := CheckContextForPathTraversal(&FileAccessed{Filename: "../../web/spec-extension/cookies", Operation: operation})
 		if result != nil {
 			t.Errorf("expected nil, got %v", result)
 		}

--- a/lib/request-processor/vulnerabilities/shell-injection/checkContextForShellInjection.go
+++ b/lib/request-processor/vulnerabilities/shell-injection/checkContextForShellInjection.go
@@ -1,23 +1,24 @@
 package shell_injection
 
 import (
+	. "main/aikido_types"
 	"main/context"
 	"main/utils"
 )
 
-func CheckContextForShellInjection(command string, operation string) *utils.InterceptorResult {
+func CheckContextForShellInjection(shellExecuted *ShellExecuted) *utils.InterceptorResult {
 	for _, source := range context.SOURCES {
 		mapss := source.CacheGet()
 
 		for str, path := range mapss {
-			if detectShellInjection(command, str) {
+			if detectShellInjection(shellExecuted.Cmd, str) {
 				return &utils.InterceptorResult{
-					Operation:     operation,
+					Operation:     shellExecuted.Operation,
 					Kind:          utils.Shell_injection,
 					Source:        source.Name,
 					PathToPayload: path,
 					Metadata: map[string]string{
-						"command": command,
+						"command": shellExecuted.Cmd,
 					},
 					Payload: str,
 				}

--- a/lib/request-processor/vulnerabilities/shell-injection/checkContextForShellInjection_test.go
+++ b/lib/request-processor/vulnerabilities/shell-injection/checkContextForShellInjection_test.go
@@ -1,6 +1,7 @@
 package shell_injection
 
 import (
+	. "main/aikido_types"
 	"main/context"
 	"main/utils"
 	"testing"
@@ -19,7 +20,7 @@ func TestCheckContextForShellInjection(t *testing.T) {
 			"route":  "/",
 		})
 		operation := "child_process.exec"
-		result := CheckContextForShellInjection("binary --domain www.example`whoami`.com", operation)
+		result := CheckContextForShellInjection(&ShellExecuted{Cmd: "binary --domain www.example`whoami`.com", Operation: operation})
 
 		if result == nil {
 			t.Errorf("expected result, got nil")
@@ -59,7 +60,7 @@ func TestCheckContextForShellInjection(t *testing.T) {
 			"route":  "/",
 		})
 
-		result := CheckContextForShellInjection("binary --domain www.example`whoami`.com", operation)
+		result := CheckContextForShellInjection(&ShellExecuted{Cmd: "binary --domain www.example`whoami`.com", Operation: operation})
 
 		if result == nil {
 			t.Errorf("expected result, got nil")

--- a/lib/request-processor/vulnerabilities/sql-injection/checkContextForSqlInjection.go
+++ b/lib/request-processor/vulnerabilities/sql-injection/checkContextForSqlInjection.go
@@ -1,6 +1,7 @@
 package sql_injection
 
 import (
+	. "main/aikido_types"
 	"main/context"
 	"main/utils"
 )
@@ -9,22 +10,22 @@ import (
  * This function goes over all the different input types in the context and checks
  * if it's a possible SQL Injection, if so the function returns an InterceptorResult
  */
-func CheckContextForSqlInjection(sql string, operation string, dialect string) *utils.InterceptorResult {
-	dialectId := utils.GetSqlDialectFromString(dialect)
+func CheckContextForSqlInjection(queryExecuted *QueryExecuted) *utils.InterceptorResult {
+	dialectId := utils.GetSqlDialectFromString(queryExecuted.Dialect)
 
 	for _, source := range context.SOURCES {
 		mapss := source.CacheGet()
 
 		for str, path := range mapss {
-			if detectSQLInjection(sql, str, dialectId) {
+			if detectSQLInjection(queryExecuted.Query, str, dialectId) {
 				return &utils.InterceptorResult{
-					Operation:     operation,
+					Operation:     queryExecuted.Operation,
 					Kind:          utils.Sql_injection,
 					Source:        source.Name,
 					PathToPayload: path,
 					Metadata: map[string]string{
-						"sql":     sql,
-						"dialect": dialect,
+						"sql":     queryExecuted.Query,
+						"dialect": queryExecuted.Dialect,
 					},
 					Payload: str,
 				}

--- a/lib/request-processor/vulnerabilities/sql-injection/checkContextForSqlInjection_test.go
+++ b/lib/request-processor/vulnerabilities/sql-injection/checkContextForSqlInjection_test.go
@@ -1,6 +1,7 @@
 package sql_injection
 
 import (
+	. "main/aikido_types"
 	"main/context"
 	"main/utils"
 	zen_internals "main/vulnerabilities/zen-internals"
@@ -21,7 +22,7 @@ func TestCheckContextForSqlInjection(t *testing.T) {
 		"route":         "/",
 	})
 
-	result := CheckContextForSqlInjection(sql, operation, "mysql")
+	result := CheckContextForSqlInjection(&QueryExecuted{Query: sql, Operation: operation, Dialect: "mysql"})
 
 	if result == nil {
 		t.Errorf("Expected result, got nil")

--- a/package/rpm/aikido.spec
+++ b/package/rpm/aikido.spec
@@ -1,5 +1,5 @@
 Name:           aikido-php-firewall
-Version:        1.0.94
+Version:        1.0.95
 Release:        1
 Summary:        Aikido PHP Extension
 License:        GPL


### PR DESCRIPTION
- Enable collect_api_schema by default
- Cache vulnerability checking results at the request level
- If the same query gets executed multiple times in the same request, check once for sql injection, store the result in cache -> subsequent calls just return the result directly
- Same applies for file access (path traversal) and executed shells (shell injection)