### PR TITLE
Linux ARM64 support

### DIFF
--- a/.devcontainer/centos/devcontainer.json
+++ b/.devcontainer/centos/devcontainer.json
@@ -5,7 +5,7 @@
     "source=${localWorkspaceFolder}/.devcontainer/shared,target=/shared,type=bind"
   ],
   "build": {
-    "platform": "linux/amd64",
+    "platform": "linux/arm64",
     "dockerfile": "Dockerfile",
     "args": {
       "PHP_VERSION": "8.1"

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -14,7 +14,7 @@ jobs:
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:
-        os: [	ubuntu-20.04, ubuntu-24.04-arm ]
+        os: [	ubuntu-20.04, ubuntu-22.04-arm ]
       fail-fast: true
 
     steps:
@@ -26,8 +26,9 @@ jobs:
 
     - name: Install dependencies
       run: |
+        sudo add-apt-repository ppa:longsleep/golang-backports
         sudo apt-get update
-        sudo apt-get install -y protobuf-compiler protobuf-compiler-grpc
+        sudo apt-get install -y golang-go protobuf-compiler protobuf-compiler-grpc
 
     - name: GO setup
       run: |

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -327,7 +327,8 @@ jobs:
           sed -i 's|#baseurl=http://mirror.centos.org|baseurl=http://vault.centos.org|g' /etc/yum.repos.d/CentOS-*
           yum install -y yum-utils
           yum install -y https://rpms.remirepo.net/enterprise/remi-release-8.4.rpm
-          yum -y install gcc python3-devel
+          yum install -y gcc
+          yum install -y python3-devel
           pip3 install flask
           pip3 install requests
           pip3 install pandas

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -329,11 +329,8 @@ jobs:
           yum install -y https://rpms.remirepo.net/enterprise/remi-release-8.4.rpm
           yum install -y gcc
           yum install -y python3-devel
-          pip3 install cython
-          pip3 install numpy
           pip3 install flask
           pip3 install requests
-          pip3 install pandas
           pip3 install psutil
           yum install -y httpd
           dnf --assumeyes module reset php

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -235,6 +235,7 @@ jobs:
           mv ~/rpmbuild/RPMS/${{ env.ARCH }}/${{ env.AIKIDO_ARTIFACT }} ~/rpmbuild/RPMS/${{ env.ARCH }}/${{ env.AIKIDO_ARTIFACT_RELEASE }}
 
       - name: Check rpm dependencies
+        if: ${{ env.ARCH }} == 'x86_64'
         run: |
           yum deplist ~/rpmbuild/RPMS/${{ env.ARCH }}/${{ env.AIKIDO_ARTIFACT_RELEASE }} | grep -E "GLIBC_2.32|GLIBC_2.34|GLIBCXX_3.4.29" && exit 1 || exit 0
       

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -235,6 +235,7 @@ jobs:
           mv ~/rpmbuild/RPMS/${{ env.ARCH }}/${{ env.AIKIDO_ARTIFACT }} ~/rpmbuild/RPMS/${{ env.ARCH }}/${{ env.AIKIDO_ARTIFACT_RELEASE }}
 
       - name: Check rpm dependencies
+        if: matrix.os == 'ubuntu-latest'
         run: |
           yum deplist ~/rpmbuild/RPMS/${{ env.ARCH }}/${{ env.AIKIDO_ARTIFACT_RELEASE }} | grep -E "GLIBC_2.32|GLIBC_2.34|GLIBCXX_3.4.29" && exit 1 || exit 0
       

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -20,6 +20,9 @@ jobs:
     - name: Checkout repository
       uses: actions/checkout@v4
 
+    - name: Get Arch
+      run: echo "ARCH=$(uname -m)" >> $GITHUB_ENV
+
     - name: Install dependencies
       run: |
         sudo apt-get update
@@ -69,7 +72,7 @@ jobs:
       uses: actions/upload-artifact@v4
       if: always()
       with:
-        name: aikido-agent
+        name: aikido-agent-${{ env.ARCH }}
         if-no-files-found: error
         path: |
           ${{ github.workspace }}/build/aikido-agent.so
@@ -78,7 +81,7 @@ jobs:
       uses: actions/upload-artifact@v4
       if: always()
       with:
-        name: aikido-request-processor
+        name: aikido-request-processor-${{ env.ARCH }}
         if-no-files-found: error
         path: |
           ${{ github.workspace }}/build/aikido-request-processor.so
@@ -99,6 +102,9 @@ jobs:
       run: |
         sudo apt-get update
         sudo apt-get install -y autoconf bison re2c libxml2-dev libssl-dev libcurl4-gnutls-dev
+
+    - name: Get Arch
+      run: echo "ARCH=$(uname -m)" >> $GITHUB_ENV
 
     - name: Get Aikido version
       run: |
@@ -140,7 +146,7 @@ jobs:
       uses: actions/upload-artifact@v4
       if: always()
       with:
-        name: ${{ env.AIKIDO_ARTIFACT }}
+        name: ${{ env.AIKIDO_ARTIFACT }}-${{ env.ARCH }}
         if-no-files-found: error
         path: |
           ${{ github.workspace }}/build/modules/${{ env.AIKIDO_ARTIFACT }}.so
@@ -182,19 +188,19 @@ jobs:
         uses: actions/download-artifact@v4
         with:
           pattern: |
-            aikido-extension-php-*
+            aikido-extension-php-*-${{ env.ARCH }}
 
       - name: Download artifacts
         uses: actions/download-artifact@v4
         with:
           pattern: |
-            aikido-agent*
+            aikido-agent-${{ env.ARCH }}
 
       - name: Download artifacts
         uses: actions/download-artifact@v4
         with:
           pattern: |
-            aikido-request-processor*
+            aikido-request-processor-${{ env.ARCH }}
 
       - name: Download Aikido Zen Internals Lib
         run: |

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -329,6 +329,7 @@ jobs:
           yum install -y https://rpms.remirepo.net/enterprise/remi-release-8.4.rpm
           yum install -y gcc
           yum install -y python3-devel
+          pip3 install cython
           pip3 install flask
           pip3 install requests
           pip3 install pandas

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -14,7 +14,7 @@ jobs:
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:
-        os: [	ubuntu-20.04, ubuntu-24.04-arm ]
+        os: [	ubuntu-20.04, ubuntu-22.04-arm ]
 
     steps:
     - name: Checkout repository

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -15,6 +15,7 @@ jobs:
     strategy:
       matrix:
         os: [	ubuntu-20.04, ubuntu-22.04-arm ]
+      fail-fast: true
 
     steps:
     - name: Checkout repository
@@ -235,6 +236,7 @@ jobs:
           mv ~/rpmbuild/RPMS/${{ env.ARCH }}/${{ env.AIKIDO_ARTIFACT }} ~/rpmbuild/RPMS/${{ env.ARCH }}/${{ env.AIKIDO_ARTIFACT_RELEASE }}
 
       - name: Check rpm dependencies
+          if: matrix.os == 'ubuntu-22.04'
         run: |
           yum deplist ~/rpmbuild/RPMS/${{ env.ARCH }}/${{ env.AIKIDO_ARTIFACT_RELEASE }} | grep -E "GLIBC_2.32|GLIBC_2.34|GLIBCXX_3.4.29" && exit 1 || exit 0
       

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -236,7 +236,7 @@ jobs:
           mv ~/rpmbuild/RPMS/${{ env.ARCH }}/${{ env.AIKIDO_ARTIFACT }} ~/rpmbuild/RPMS/${{ env.ARCH }}/${{ env.AIKIDO_ARTIFACT_RELEASE }}
 
       - name: Check rpm dependencies
-          if: matrix.os == 'ubuntu-22.04'
+        if: matrix.os == 'ubuntu-22.04'
         run: |
           yum deplist ~/rpmbuild/RPMS/${{ env.ARCH }}/${{ env.AIKIDO_ARTIFACT_RELEASE }} | grep -E "GLIBC_2.32|GLIBC_2.34|GLIBCXX_3.4.29" && exit 1 || exit 0
       

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -384,7 +384,7 @@ jobs:
     needs: [ build_deb ]
     strategy:
       matrix:
-        os: ['ubuntu-24.04', 'ubuntu-22.04', 'ubuntu-20.04', 'ubuntu-22.04-arm', 'ubuntu-24.04-arm']
+        os: ['ubuntu-24.04', 'ubuntu-22.04', 'ubuntu-20.04', 'ubuntu-24.04-arm']
         php_version: ['7.3', '7.4', '8.0', '8.1', '8.2', '8.3', '8.4']
         server: ['nginx-php-fpm', 'apache-mod-php', 'php-built-in']
       fail-fast: false

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -11,7 +11,10 @@ on:
 
 jobs:
   build_libs:
-    runs-on: ubuntu-20.04
+    runs-on: ${{ matrix.os }}
+    strategy:
+      matrix:
+        os: [	ubuntu-20.04, ubuntu-24.04-arm ]
 
     steps:
     - name: Checkout repository
@@ -81,10 +84,11 @@ jobs:
           ${{ github.workspace }}/build/aikido-request-processor.so
 
   build_php_extension:
-    runs-on: ubuntu-20.04
+    runs-on: ${{ matrix.os }}
     strategy:
       matrix:
         php_version: ['7.3', '7.4', '8.0', '8.1', '8.2', '8.3', '8.4']
+        os: [	ubuntu-20.04, ubuntu-24.04-arm ]
       fail-fast: false
 
     steps:
@@ -143,9 +147,12 @@ jobs:
           ${{ github.workspace }}/tests/*.diff
 
   build_rpm:
-    runs-on: ubuntu-latest
+    runs-on: ${{ matrix.os }}
     container:
       image: centos:latest
+    strategy:
+      matrix:
+        os: ['ubuntu-latest', 'ubuntu-latest-arm']
     needs: [ build_libs, build_php_extension ]
     steps:
       - name: Checkout repository
@@ -160,12 +167,15 @@ jobs:
           yum -y install rpmdevtools
           yum -y install jq
 
+      - name: Get Arch
+        run: echo "ARCH=$(uname -m)" >> $GITHUB_ENV
+
       - name: Get Aikido version
         run: |
           AIKIDO_VERSION=$(grep '#define PHP_AIKIDO_VERSION' lib/php-extension/include/php_aikido.h | awk -F'"' '{print $2}')
           echo $AIKIDO_VERSION
           echo "AIKIDO_VERSION=$AIKIDO_VERSION" >> $GITHUB_ENV
-          echo "AIKIDO_LIBZEN=libzen_internals_x86_64-unknown-linux-gnu.so" >> $GITHUB_ENV
+          echo "AIKIDO_LIBZEN=libzen_internals_${{ env.ARCH }}-unknown-linux-gnu.so" >> $GITHUB_ENV
           echo "AIKIDO_LIBZEN_VERSION=0.1.35" >> $GITHUB_ENV
 
       - name: Download artifacts
@@ -205,8 +215,8 @@ jobs:
 
       - name: Setup RPM for prod
         run: |
-          echo "AIKIDO_ARTIFACT=aikido-php-firewall-$AIKIDO_VERSION-1.x86_64.rpm" >> $GITHUB_ENV
-          echo "AIKIDO_ARTIFACT_RELEASE=aikido-php-firewall.x86_64.rpm" >> $GITHUB_ENV
+          echo "AIKIDO_ARTIFACT=aikido-php-firewall-$AIKIDO_VERSION-1.${{ env.ARCH }}.rpm" >> $GITHUB_ENV
+          echo "AIKIDO_ARTIFACT_RELEASE=aikido-php-firewall.${{ env.ARCH }}.rpm" >> $GITHUB_ENV
           sed -i "s/aikido.so/aikido-${{ env.AIKIDO_VERSION }}.so/" ~/rpmbuild/SOURCES/aikido-php-firewall-${{ env.AIKIDO_VERSION }}/opt/aikido-${{ env.AIKIDO_VERSION }}/aikido.ini
 
       - name: Build rpm package
@@ -215,12 +225,12 @@ jobs:
           tar czvf ~/rpmbuild/SOURCES/aikido-php-firewall-${{ env.AIKIDO_VERSION }}.tar.gz *
           rm -rf ~/rpmbuild/SOURCES/aikido-php-firewall-${{ env.AIKIDO_VERSION }}
           rpmbuild -ba ~/rpmbuild/SPECS/aikido.spec
-          ls -l ~/rpmbuild/RPMS/x86_64/
-          mv ~/rpmbuild/RPMS/x86_64/${{ env.AIKIDO_ARTIFACT }} ~/rpmbuild/RPMS/x86_64/${{ env.AIKIDO_ARTIFACT_RELEASE }}
+          ls -l ~/rpmbuild/RPMS/${{ env.ARCH }}/
+          mv ~/rpmbuild/RPMS/${{ env.ARCH }}/${{ env.AIKIDO_ARTIFACT }} ~/rpmbuild/RPMS/${{ env.ARCH }}/${{ env.AIKIDO_ARTIFACT_RELEASE }}
 
       - name: Check rpm dependencies
         run: |
-          yum deplist ~/rpmbuild/RPMS/x86_64/${{ env.AIKIDO_ARTIFACT_RELEASE }} | grep -E "GLIBC_2.32|GLIBC_2.34|GLIBCXX_3.4.29" && exit 1 || exit 0
+          yum deplist ~/rpmbuild/RPMS/${{ env.ARCH }}/${{ env.AIKIDO_ARTIFACT_RELEASE }} | grep -E "GLIBC_2.32|GLIBC_2.34|GLIBCXX_3.4.29" && exit 1 || exit 0
       
       - name: Archive rpm package
         uses: actions/upload-artifact@v4
@@ -228,10 +238,13 @@ jobs:
           name: ${{ env.AIKIDO_ARTIFACT_RELEASE }}
           if-no-files-found: error
           path: |
-            ~/rpmbuild/RPMS/x86_64/${{ env.AIKIDO_ARTIFACT_RELEASE }}
+            ~/rpmbuild/RPMS/${{ env.ARCH }}/${{ env.AIKIDO_ARTIFACT_RELEASE }}
 
   build_deb:
-    runs-on: ubuntu-20.04
+    runs-on: ${{ matrix.os }}
+    strategy:
+      matrix:
+        os: ['ubuntu-20.04', 'ubuntu-22.04-arm']
     needs: [ build_rpm ]
     steps:
       - name: Checkout repository
@@ -248,20 +261,23 @@ jobs:
           sudo apt-get update
           sudo apt-get install -y alien
 
+      - name: Get Arch
+        run: echo "ARCH=$(uname -m)" >> $GITHUB_ENV
+
       - name: Get Aikido version
         run: |
           AIKIDO_VERSION=$(grep '#define PHP_AIKIDO_VERSION' lib/php-extension/include/php_aikido.h | awk -F'"' '{print $2}')
           echo $AIKIDO_VERSION
           echo "AIKIDO_VERSION=$AIKIDO_VERSION" >> $GITHUB_ENV
-          echo "AIKIDO_RPM=aikido-php-firewall.x86_64.rpm" >> $GITHUB_ENV
-          echo "AIKIDO_ARTIFACT=aikido-php-firewall.x86_64.deb" >> $GITHUB_ENV
+          echo "AIKIDO_RPM=aikido-php-firewall.${{ env.ARCH }}.rpm" >> $GITHUB_ENV
+          echo "AIKIDO_ARTIFACT=aikido-php-firewall.${{ env.ARCH }}.deb" >> $GITHUB_ENV
       
       - name: Build deb
         run: |
           ls -R
           sudo alien --to-deb --scripts --keep-version ${{ env.AIKIDO_RPM }}/${{ env.AIKIDO_RPM }}
           ls -R
-          mv aikido-php-firewall_${{ env.AIKIDO_VERSION }}-1_amd64.deb ${{ env.AIKIDO_ARTIFACT }}
+          mv aikido-php-firewall_${{ env.AIKIDO_VERSION }}-1_${{ env.ARCH }}.deb ${{ env.AIKIDO_ARTIFACT }}
   
       - name: Archive deb package
         uses: actions/upload-artifact@v4
@@ -272,7 +288,7 @@ jobs:
             ${{ env.AIKIDO_ARTIFACT }}
 
   test_php_centos:
-    runs-on: ubuntu-latest
+    runs-on: ${{ matrix.os }}
     container:
       image: centos:latest
     needs: [ build_rpm ]
@@ -280,6 +296,7 @@ jobs:
       matrix:
         php_version: ['7.3', '7.4', '8.0', '8.1', '8.2', '8.3', '8.4']
         server: ['nginx-php-fpm', 'apache-mod-php', 'php-built-in']
+        os: ['ubuntu-latest', 'ubuntu-latest-arm']
       fail-fast: false
     steps:
       - name: Checkout repository
@@ -306,6 +323,9 @@ jobs:
           yum install -y nginx
           yum install -y php-fpm
 
+      - name: Get Arch
+        run: echo "ARCH=$(uname -m)" >> $GITHUB_ENV
+
       - name: Check PHP setup
         run: |
           php -v
@@ -316,7 +336,7 @@ jobs:
           AIKIDO_VERSION=$(grep '#define PHP_AIKIDO_VERSION' lib/php-extension/include/php_aikido.h | awk -F'"' '{print $2}')
           echo $AIKIDO_VERSION
           echo "AIKIDO_VERSION=$AIKIDO_VERSION" >> $GITHUB_ENV
-          echo "AIKIDO_RPM=aikido-php-firewall.x86_64.rpm" >> $GITHUB_ENV
+          echo "AIKIDO_RPM=aikido-php-firewall.${{ env.ARCH }}.rpm" >> $GITHUB_ENV
       
       - name: Download artifacts
         uses: actions/download-artifact@v4
@@ -337,14 +357,13 @@ jobs:
         run: |
           cd tools
           python3 run_server_tests.py ../tests/server ../tests/testlib --server=${{ matrix.server }}
-            
 
   test_php_ubuntu:
     runs-on: ${{ matrix.os }}
     needs: [ build_deb ]
     strategy:
       matrix:
-        os: ['ubuntu-latest', 'ubuntu-20.04']
+        os: ['ubuntu-latest', 'ubuntu-20.04', 'ubuntu-22.04-arm']
         php_version: ['7.3', '7.4', '8.0', '8.1', '8.2', '8.3', '8.4']
         server: ['nginx-php-fpm', 'apache-mod-php', 'php-built-in']
       fail-fast: false
@@ -358,12 +377,15 @@ jobs:
           pattern: |
             aikido-php-firewall*
 
+      - name: Get Arch
+        run: echo "ARCH=$(uname -m)" >> $GITHUB_ENV
+
       - name: Set env
         run: |
           AIKIDO_VERSION=$(grep '#define PHP_AIKIDO_VERSION' lib/php-extension/include/php_aikido.h | awk -F'"' '{print $2}')
           echo $AIKIDO_VERSION
           echo "AIKIDO_VERSION=$AIKIDO_VERSION" >> $GITHUB_ENV
-          echo "AIKIDO_DEB=aikido-php-firewall.x86_64.deb" >> $GITHUB_ENV
+          echo "AIKIDO_DEB=aikido-php-firewall.${{ env.ARCH }}.deb" >> $GITHUB_ENV
 
       - name: Setup nginx & php-fpm
         run: |

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -320,6 +320,7 @@ jobs:
 
       - name: Setup
         run: |
+          uname -a
           cat /etc/centos-release
           cd /etc/yum.repos.d/
           sed -i 's/mirrorlist/#mirrorlist/g' /etc/yum.repos.d/CentOS-*
@@ -344,6 +345,7 @@ jobs:
 
       - name: Check PHP setup
         run: |
+          uname -m
           php -v
           php -i
 

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -262,7 +262,7 @@ jobs:
 
       - name: Get deb arch
         run: |
-          if "${{ env.ARCH }}" = "x86_64"; then
+          if [ "${{ env.ARCH }}" = "x86_64" ]; then
             echo "DEB_ARCH=amd64" >> $GITHUB_ENV
           else
             echo "DEB_ARCH=${{ env.ARCH }}" >> $GITHUB_ENV

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -93,7 +93,7 @@ jobs:
     strategy:
       matrix:
         php_version: ['7.3', '7.4', '8.0', '8.1', '8.2', '8.3', '8.4']
-        os: [	ubuntu-20.04, ubuntu-24.04-arm ]
+        os: [	ubuntu-20.04, ubuntu-22.04-arm ]
       fail-fast: true
 
     steps:

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -158,7 +158,7 @@ jobs:
       image: centos:latest
     strategy:
       matrix:
-        os: ['ubuntu-latest', 'ubuntu-24.04-arm']
+        os: ['ubuntu-22.04', 'ubuntu-22.04-arm']
     needs: [ build_libs, build_php_extension ]
     steps:
       - name: Checkout repository
@@ -235,7 +235,6 @@ jobs:
           mv ~/rpmbuild/RPMS/${{ env.ARCH }}/${{ env.AIKIDO_ARTIFACT }} ~/rpmbuild/RPMS/${{ env.ARCH }}/${{ env.AIKIDO_ARTIFACT_RELEASE }}
 
       - name: Check rpm dependencies
-        if: matrix.os == 'ubuntu-latest'
         run: |
           yum deplist ~/rpmbuild/RPMS/${{ env.ARCH }}/${{ env.AIKIDO_ARTIFACT_RELEASE }} | grep -E "GLIBC_2.32|GLIBC_2.34|GLIBCXX_3.4.29" && exit 1 || exit 0
       
@@ -251,7 +250,7 @@ jobs:
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:
-        os: ['ubuntu-latest', 'ubuntu-24.04-arm']
+        os: ['ubuntu-22.04', 'ubuntu-22.04-arm']
     needs: [ build_rpm ]
     steps:
       - name: Checkout repository
@@ -312,7 +311,7 @@ jobs:
       matrix:
         php_version: ['7.3', '7.4', '8.0', '8.1', '8.2', '8.3', '8.4']
         server: ['nginx-php-fpm', 'apache-mod-php', 'php-built-in']
-        os: ['ubuntu-latest', 'ubuntu-24.04-arm']
+        os: ['ubuntu-22.04', 'ubuntu-24.04', 'ubuntu-22.04-arm', 'ubuntu-24.04-arm']
       fail-fast: false
     steps:
       - name: Checkout repository
@@ -381,7 +380,7 @@ jobs:
     needs: [ build_deb ]
     strategy:
       matrix:
-        os: ['ubuntu-latest', 'ubuntu-20.04', 'ubuntu-24.04-arm', 'ubuntu-22.04-arm']
+        os: ['ubuntu-24.04', 'ubuntu-22.04', 'ubuntu-20.04', 'ubuntu-24.04-arm', 'ubuntu-22.04-arm']
         php_version: ['7.3', '7.4', '8.0', '8.1', '8.2', '8.3', '8.4']
         server: ['nginx-php-fpm', 'apache-mod-php', 'php-built-in']
       fail-fast: false
@@ -451,7 +450,7 @@ jobs:
           sudo dpkg -i -E ${{ env.AIKIDO_DEB }}/${{ env.AIKIDO_DEB }}
 
       - name: Run CLI tests
-        if: matrix.os == 'ubuntu-latest' || matrix.os == 'ubuntu-22.04-arm'
+        if: matrix.os == 'ubuntu-24.04' || matrix.os == 'ubuntu-24.04-arm'
         run: |
           cd ${{ github.workspace }}
           php lib/php-extension/run-tests.php ./tests/cli

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -452,7 +452,7 @@ jobs:
           sudo dpkg -i -E ${{ env.AIKIDO_DEB }}/${{ env.AIKIDO_DEB }}
 
       - name: Run CLI tests
-        if: matrix.os == 'ubuntu-latest'
+        if: matrix.os == 'ubuntu-latest' || matrix.os == 'ubuntu-22.04-arm'
         run: |
           cd ${{ github.workspace }}
           php lib/php-extension/run-tests.php ./tests/cli

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -384,7 +384,7 @@ jobs:
     needs: [ build_deb ]
     strategy:
       matrix:
-        os: ['ubuntu-24.04', 'ubuntu-22.04', 'ubuntu-20.04', 'ubuntu-24.04-arm']
+        os: ['ubuntu-24.04', 'ubuntu-22.04', 'ubuntu-20.04', 'ubuntu-22.04-arm', 'ubuntu-24.04-arm']
         php_version: ['7.3', '7.4', '8.0', '8.1', '8.2', '8.3', '8.4']
         server: ['nginx-php-fpm', 'apache-mod-php', 'php-built-in']
       fail-fast: false

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -385,7 +385,7 @@ jobs:
     needs: [ build_deb ]
     strategy:
       matrix:
-        os: ['ubuntu-24.04', 'ubuntu-22.04', 'ubuntu-20.04', 'ubuntu-24.04-arm']
+        os: ['ubuntu-24.04', 'ubuntu-22.04', 'ubuntu-20.04', 'ubuntu-22.04-arm', 'ubuntu-24.04-arm']
         php_version: ['7.3', '7.4', '8.0', '8.1', '8.2', '8.3', '8.4']
         server: ['nginx-php-fpm', 'apache-mod-php', 'php-built-in']
       fail-fast: false

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -315,7 +315,7 @@ jobs:
       matrix:
         php_version: ['7.3', '7.4', '8.0', '8.1', '8.2', '8.3', '8.4']
         server: ['nginx-php-fpm', 'apache-mod-php', 'php-built-in']
-        os: ['ubuntu-22.04', 'ubuntu-24.04', 'ubuntu-24.04-arm']
+        os: ['ubuntu-20.04', 'ubuntu-22.04', 'ubuntu-24.04']
       fail-fast: false
     steps:
       - name: Checkout repository

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -209,7 +209,7 @@ jobs:
       - name: Prepare rpm package
         run: |
           mv aikido-agent-${{ env.ARCH }}/aikido-agent.so package/rpm/opt/aikido/aikido-agent.so
-          mv aikido-request-processor${{ env.ARCH }}/aikido-request-processor.so package/rpm/opt/aikido/aikido-request-processor.so
+          mv aikido-request-processor-${{ env.ARCH }}/aikido-request-processor.so package/rpm/opt/aikido/aikido-request-processor.so
           mv ${{ env.AIKIDO_LIBZEN }} package/rpm/opt/aikido/${{ env.AIKIDO_LIBZEN }}
           mv aikido-extension-php-*/build/modules/aikido-extension-php-* package/rpm/opt/aikido/
           mv package/rpm/opt/aikido package/rpm/opt/aikido-${{ env.AIKIDO_VERSION }}
@@ -256,19 +256,19 @@ jobs:
       - name: Checkout repository
         uses: actions/checkout@v4
 
+      - name: Get Arch
+        run: echo "ARCH=$(uname -m)" >> $GITHUB_ENV
+
       - name: Download artifacts
         uses: actions/download-artifact@v4
         with:
           pattern: |
-            aikido-php-firewall*
+            aikido-php-firewall.${{ env.ARCH }}.rpm
 
       - name: Install dependencies
         run: |
           sudo apt-get update
           sudo apt-get install -y alien
-
-      - name: Get Arch
-        run: echo "ARCH=$(uname -m)" >> $GITHUB_ENV
 
       - name: Get Aikido version
         run: |
@@ -348,7 +348,7 @@ jobs:
         uses: actions/download-artifact@v4
         with:
           pattern: |
-            aikido-php-firewall*
+            ${{ env.AIKIDO_RPM }}
 
       - name: Install RPM
         run: |
@@ -377,12 +377,6 @@ jobs:
       - name: Checkout repository
         uses: actions/checkout@v4
 
-      - name: Download artifacts
-        uses: actions/download-artifact@v4
-        with:
-          pattern: |
-            aikido-php-firewall*
-
       - name: Get Arch
         run: echo "ARCH=$(uname -m)" >> $GITHUB_ENV
 
@@ -392,6 +386,12 @@ jobs:
           echo $AIKIDO_VERSION
           echo "AIKIDO_VERSION=$AIKIDO_VERSION" >> $GITHUB_ENV
           echo "AIKIDO_DEB=aikido-php-firewall.${{ env.ARCH }}.deb" >> $GITHUB_ENV
+
+      - name: Download artifacts
+        uses: actions/download-artifact@v4
+        with:
+          pattern: |
+            ${{ env.AIKIDO_DEB }}
 
       - name: Setup nginx & php-fpm
         run: |

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -27,10 +27,12 @@ jobs:
     - name: Install dependencies
       run: |
         sudo apt-get update
+        sudo apt-get install golang
         sudo apt-get install -y protobuf-compiler protobuf-compiler-grpc
 
     - name: GO setup
       run: |
+        go version
         go install google.golang.org/protobuf/cmd/protoc-gen-go@latest
         go install google.golang.org/grpc/cmd/protoc-gen-go-grpc@latest
         echo "$HOME/go/bin" >> $GITHUB_PATH

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -158,7 +158,7 @@ jobs:
       image: centos:latest
     strategy:
       matrix:
-        os: ['ubuntu-latest', 'ubuntu-latest-arm']
+        os: ['ubuntu-latest', 'ubuntu-24.04-arm']
     needs: [ build_libs, build_php_extension ]
     steps:
       - name: Checkout repository
@@ -302,7 +302,7 @@ jobs:
       matrix:
         php_version: ['7.3', '7.4', '8.0', '8.1', '8.2', '8.3', '8.4']
         server: ['nginx-php-fpm', 'apache-mod-php', 'php-built-in']
-        os: ['ubuntu-latest', 'ubuntu-latest-arm']
+        os: ['ubuntu-latest', 'ubuntu-24.04-arm']
       fail-fast: false
     steps:
       - name: Checkout repository

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -330,6 +330,7 @@ jobs:
           yum install -y gcc
           yum install -y python3-devel
           pip3 install cython
+          pip3 install numpy
           pip3 install flask
           pip3 install requests
           pip3 install pandas

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -264,6 +264,8 @@ jobs:
         run: |
           if [ "${{ env.ARCH }}" = "x86_64" ]; then
             echo "DEB_ARCH=amd64" >> $GITHUB_ENV
+          elif [ "$ARCH" = "aarch64" ]; then
+            echo "DEB_ARCH=arm64" >> $GITHUB_ENV
           else
             echo "DEB_ARCH=${{ env.ARCH }}" >> $GITHUB_ENV
           fi
@@ -290,6 +292,7 @@ jobs:
       - name: Build deb
         run: |
           sudo alien --to-deb --scripts --keep-version ${{ env.AIKIDO_RPM }}/${{ env.AIKIDO_RPM }}
+          ls -R
           mv aikido-php-firewall_${{ env.AIKIDO_VERSION }}-1_${{ env.DEB_ARCH }}.deb ${{ env.AIKIDO_ARTIFACT }}
   
       - name: Archive deb package

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -160,7 +160,7 @@ jobs:
     strategy:
       matrix:
         os: ['ubuntu-22.04', 'ubuntu-24.04-arm']
-        fail-fast: true
+      fail-fast: true
     needs: [ build_libs, build_php_extension ]
     steps:
       - name: Checkout repository

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -235,7 +235,7 @@ jobs:
           mv ~/rpmbuild/RPMS/${{ env.ARCH }}/${{ env.AIKIDO_ARTIFACT }} ~/rpmbuild/RPMS/${{ env.ARCH }}/${{ env.AIKIDO_ARTIFACT_RELEASE }}
 
       - name: Check rpm dependencies
-        if: ${{ env.ARCH }} == 'x86_64'
+        if: matrix.os == 'ubuntu-latest'
         run: |
           yum deplist ~/rpmbuild/RPMS/${{ env.ARCH }}/${{ env.AIKIDO_ARTIFACT_RELEASE }} | grep -E "GLIBC_2.32|GLIBC_2.34|GLIBCXX_3.4.29" && exit 1 || exit 0
       

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -260,6 +260,14 @@ jobs:
       - name: Get Arch
         run: echo "ARCH=$(uname -m)" >> $GITHUB_ENV
 
+      - name: Get deb arch
+        run: |
+          if "${{ env.ARCH }}" = "x86_64"; then
+            echo "DEB_ARCH=amd64" >> $GITHUB_ENV
+          else
+            echo "DEB_ARCH=${{ env.ARCH }}" >> $GITHUB_ENV
+          fi
+
       - name: Download artifacts
         uses: actions/download-artifact@v4
         with:
@@ -277,14 +285,12 @@ jobs:
           echo $AIKIDO_VERSION
           echo "AIKIDO_VERSION=$AIKIDO_VERSION" >> $GITHUB_ENV
           echo "AIKIDO_RPM=aikido-php-firewall.${{ env.ARCH }}.rpm" >> $GITHUB_ENV
-          echo "AIKIDO_ARTIFACT=aikido-php-firewall.${{ env.ARCH }}.deb" >> $GITHUB_ENV
+          echo "AIKIDO_ARTIFACT=aikido-php-firewall.${{ env.ARCH }}.deb" >> $GITHUB_ENV    
       
       - name: Build deb
         run: |
-          ls -R
           sudo alien --to-deb --scripts --keep-version ${{ env.AIKIDO_RPM }}/${{ env.AIKIDO_RPM }}
-          ls -R
-          mv aikido-php-firewall_${{ env.AIKIDO_VERSION }}-1_${{ env.ARCH }}.deb ${{ env.AIKIDO_ARTIFACT }}
+          mv aikido-php-firewall_${{ env.AIKIDO_VERSION }}-1_${{ env.DEB_ARCH }}.deb ${{ env.AIKIDO_ARTIFACT }}
   
       - name: Archive deb package
         uses: actions/upload-artifact@v4

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -208,8 +208,8 @@ jobs:
 
       - name: Prepare rpm package
         run: |
-          mv aikido-agent/aikido-agent.so package/rpm/opt/aikido/aikido-agent.so
-          mv aikido-request-processor/aikido-request-processor.so package/rpm/opt/aikido/aikido-request-processor.so
+          mv aikido-agent-${{ env.ARCH }}/aikido-agent.so package/rpm/opt/aikido/aikido-agent.so
+          mv aikido-request-processor${{ env.ARCH }}/aikido-request-processor.so package/rpm/opt/aikido/aikido-request-processor.so
           mv ${{ env.AIKIDO_LIBZEN }} package/rpm/opt/aikido/${{ env.AIKIDO_LIBZEN }}
           mv aikido-extension-php-*/build/modules/aikido-extension-php-* package/rpm/opt/aikido/
           mv package/rpm/opt/aikido package/rpm/opt/aikido-${{ env.AIKIDO_VERSION }}

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -14,7 +14,7 @@ jobs:
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:
-        os: [	ubuntu-20.04, ubuntu-22.04-arm ]
+        os: [	ubuntu-20.04, ubuntu-24.04-arm ]
       fail-fast: true
 
     steps:
@@ -27,12 +27,10 @@ jobs:
     - name: Install dependencies
       run: |
         sudo apt-get update
-        sudo apt-get install golang
         sudo apt-get install -y protobuf-compiler protobuf-compiler-grpc
 
     - name: GO setup
       run: |
-        go version
         go install google.golang.org/protobuf/cmd/protoc-gen-go@latest
         go install google.golang.org/grpc/cmd/protoc-gen-go-grpc@latest
         echo "$HOME/go/bin" >> $GITHUB_PATH
@@ -94,8 +92,8 @@ jobs:
     strategy:
       matrix:
         php_version: ['7.3', '7.4', '8.0', '8.1', '8.2', '8.3', '8.4']
-        os: [	ubuntu-20.04, ubuntu-22.04-arm ]
-      fail-fast: false
+        os: [	ubuntu-20.04, ubuntu-24.04-arm ]
+      fail-fast: true
 
     steps:
     - name: Checkout repository
@@ -161,7 +159,8 @@ jobs:
       image: centos:latest
     strategy:
       matrix:
-        os: ['ubuntu-22.04', 'ubuntu-22.04-arm']
+        os: ['ubuntu-22.04', 'ubuntu-24.04-arm']
+        fail-fast: true
     needs: [ build_libs, build_php_extension ]
     steps:
       - name: Checkout repository
@@ -254,7 +253,8 @@ jobs:
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:
-        os: ['ubuntu-22.04', 'ubuntu-22.04-arm']
+        os: ['ubuntu-22.04', 'ubuntu-24.04-arm']
+      fail-fast: true
     needs: [ build_rpm ]
     steps:
       - name: Checkout repository
@@ -315,7 +315,7 @@ jobs:
       matrix:
         php_version: ['7.3', '7.4', '8.0', '8.1', '8.2', '8.3', '8.4']
         server: ['nginx-php-fpm', 'apache-mod-php', 'php-built-in']
-        os: ['ubuntu-22.04', 'ubuntu-24.04', 'ubuntu-22.04-arm', 'ubuntu-24.04-arm']
+        os: ['ubuntu-22.04', 'ubuntu-24.04', 'ubuntu-24.04-arm']
       fail-fast: false
     steps:
       - name: Checkout repository
@@ -384,7 +384,7 @@ jobs:
     needs: [ build_deb ]
     strategy:
       matrix:
-        os: ['ubuntu-24.04', 'ubuntu-22.04', 'ubuntu-20.04', 'ubuntu-24.04-arm', 'ubuntu-22.04-arm']
+        os: ['ubuntu-24.04', 'ubuntu-22.04', 'ubuntu-20.04', 'ubuntu-24.04-arm']
         php_version: ['7.3', '7.4', '8.0', '8.1', '8.2', '8.3', '8.4']
         server: ['nginx-php-fpm', 'apache-mod-php', 'php-built-in']
       fail-fast: false

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -91,7 +91,7 @@ jobs:
     strategy:
       matrix:
         php_version: ['7.3', '7.4', '8.0', '8.1', '8.2', '8.3', '8.4']
-        os: [	ubuntu-20.04, ubuntu-24.04-arm ]
+        os: [	ubuntu-20.04, ubuntu-22.04-arm ]
       fail-fast: false
 
     steps:
@@ -235,7 +235,6 @@ jobs:
           mv ~/rpmbuild/RPMS/${{ env.ARCH }}/${{ env.AIKIDO_ARTIFACT }} ~/rpmbuild/RPMS/${{ env.ARCH }}/${{ env.AIKIDO_ARTIFACT_RELEASE }}
 
       - name: Check rpm dependencies
-        if: matrix.os == 'ubuntu-latest'
         run: |
           yum deplist ~/rpmbuild/RPMS/${{ env.ARCH }}/${{ env.AIKIDO_ARTIFACT_RELEASE }} | grep -E "GLIBC_2.32|GLIBC_2.34|GLIBCXX_3.4.29" && exit 1 || exit 0
       
@@ -251,7 +250,7 @@ jobs:
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:
-        os: ['ubuntu-20.04', 'ubuntu-22.04-arm']
+        os: ['ubuntu-latest', 'ubuntu-24.04-arm']
     needs: [ build_rpm ]
     steps:
       - name: Checkout repository
@@ -382,7 +381,7 @@ jobs:
     needs: [ build_deb ]
     strategy:
       matrix:
-        os: ['ubuntu-latest', 'ubuntu-20.04', 'ubuntu-22.04-arm']
+        os: ['ubuntu-latest', 'ubuntu-20.04', 'ubuntu-24.04-arm', 'ubuntu-22.04-arm']
         php_version: ['7.3', '7.4', '8.0', '8.1', '8.2', '8.3', '8.4']
         server: ['nginx-php-fpm', 'apache-mod-php', 'php-built-in']
       fail-fast: false

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -9,7 +9,7 @@ jobs:
   build:
     uses: ./.github/workflows/build.yml
   release:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04
     needs: build
     permissions:
       contents: write

--- a/README.md
+++ b/README.md
@@ -37,13 +37,13 @@ Prerequisites:
 #### For Red Hat-based Systems (RHEL, CentOS, Fedora)
 
 ```
-rpm -Uvh --oldpackage https://github.com/AikidoSec/firewall-php/releases/download/v1.0.107/aikido-php-firewall.x86_64.rpm
+rpm -Uvh --oldpackage https://github.com/AikidoSec/firewall-php/releases/download/v1.0.108/aikido-php-firewall.x86_64.rpm
 ```
 
 #### For Debian-based Systems (Debian, Ubuntu)
 
 ```
-curl -L -O https://github.com/AikidoSec/firewall-php/releases/download/v1.0.107/aikido-php-firewall.x86_64.deb
+curl -L -O https://github.com/AikidoSec/firewall-php/releases/download/v1.0.108/aikido-php-firewall.x86_64.deb
 dpkg -i -E ./aikido-php-firewall.x86_64.deb
 ```
 

--- a/docs/aws-elastic-beanstalk.md
+++ b/docs/aws-elastic-beanstalk.md
@@ -4,7 +4,7 @@
 ```
 commands:
   aikido-php-firewall:
-    command: "rpm -Uvh --oldpackage https://github.com/AikidoSec/firewall-php/releases/download/v1.0.107/aikido-php-firewall.x86_64.rpm"
+    command: "rpm -Uvh --oldpackage https://github.com/AikidoSec/firewall-php/releases/download/v1.0.108/aikido-php-firewall.x86_64.rpm"
     ignoreErrors: true
 
 files:

--- a/docs/fly-io.md
+++ b/docs/fly-io.md
@@ -15,7 +15,7 @@ You can find their values in the Aikido platform.
 #!/usr/bin/env bash
 cd /tmp
 
-curl -L -O https://github.com/AikidoSec/firewall-php/releases/download/v1.0.107/aikido-php-firewall.x86_64.deb
+curl -L -O https://github.com/AikidoSec/firewall-php/releases/download/v1.0.108/aikido-php-firewall.x86_64.deb
 dpkg -i -E ./aikido-php-firewall.x86_64.deb
 ```
 

--- a/docs/laravel-forge.md
+++ b/docs/laravel-forge.md
@@ -19,7 +19,7 @@ cd /tmp
 
 # Install commands from the "Manual install" section below, based on your OS
 
-curl -L -O https://github.com/AikidoSec/firewall-php/releases/download/v1.0.107/aikido-php-firewall.x86_64.deb
+curl -L -O https://github.com/AikidoSec/firewall-php/releases/download/v1.0.108/aikido-php-firewall.x86_64.deb
 dpkg -i -E ./aikido-php-firewall.x86_64.deb
 
 # Restarting the php services in order to load the Aikido PHP Firewall

--- a/lib/agent/globals/constants.go
+++ b/lib/agent/globals/constants.go
@@ -1,7 +1,7 @@
 package globals
 
 const (
-	Version                             = "1.0.107"
+	Version                             = "1.0.108"
 	ConfigUpdatedAtMethod               = "GET"
 	ConfigUpdatedAtAPI                  = "/config"
 	ConfigAPIMethod                     = "GET"

--- a/lib/php-extension/include/php_aikido.h
+++ b/lib/php-extension/include/php_aikido.h
@@ -3,7 +3,7 @@
 extern zend_module_entry aikido_module_entry;
 #define phpext_aikido_ptr &aikido_module_entry
 
-#define PHP_AIKIDO_VERSION "1.0.107"
+#define PHP_AIKIDO_VERSION "1.0.108"
 
 #if defined(ZTS) && defined(COMPILE_DL_AIKIDO)
 ZEND_TSRMLS_CACHE_EXTERN()

--- a/lib/request-processor/globals/globals.go
+++ b/lib/request-processor/globals/globals.go
@@ -13,5 +13,5 @@ var CloudConfig CloudConfigData
 var CloudConfigMutex sync.Mutex
 
 const (
-	Version = "1.0.107"
+	Version = "1.0.108"
 )

--- a/lib/request-processor/utils/utils.go
+++ b/lib/request-processor/utils/utils.go
@@ -6,6 +6,7 @@ import (
 	"main/globals"
 	"main/log"
 	"net"
+	"runtime"
 	"strings"
 
 	"github.com/seancfoley/ipaddress-go/ipaddr"
@@ -248,4 +249,14 @@ func ArrayContains(array []string, search string) bool {
 		}
 	}
 	return false
+}
+
+func GetArch() string {
+	switch runtime.GOARCH {
+	case "amd64":
+		return "x86_64"
+	case "arm64":
+		return "aarch64"
+	}
+	panic(fmt.Sprintf("Running on unsupported architecture \"%s\"!", runtime.GOARCH))
 }

--- a/lib/request-processor/vulnerabilities/zen-internals/zen_internals.go
+++ b/lib/request-processor/vulnerabilities/zen-internals/zen_internals.go
@@ -18,8 +18,10 @@ int call_detect_sql_injection(detect_sql_injection_func func, const char* query,
 */
 import "C"
 import (
+	"fmt"
 	"main/globals"
 	"main/log"
+	"main/utils"
 	"unsafe"
 )
 
@@ -29,7 +31,7 @@ var (
 )
 
 func Init() bool {
-	zenInternalsLibPath := C.CString("/opt/aikido-" + globals.Version + "/libzen_internals_x86_64-unknown-linux-gnu.so")
+	zenInternalsLibPath := C.CString(fmt.Sprintf("/opt/aikido-%s/libzen_internals_%s-unknown-linux-gnu.so", globals.Version, utils.GetArch()))
 	defer C.free(unsafe.Pointer(zenInternalsLibPath))
 
 	handle := C.dlopen(zenInternalsLibPath, C.RTLD_LAZY)

--- a/package/rpm/aikido.spec
+++ b/package/rpm/aikido.spec
@@ -1,5 +1,5 @@
 Name:           aikido-php-firewall
-Version:        1.0.107
+Version:        1.0.108
 Release:        1
 Summary:        Aikido PHP Extension
 License:        GPL

--- a/tools/dpkg_install.sh
+++ b/tools/dpkg_install.sh
@@ -1,5 +1,5 @@
-
+arch=$(uname -m)
 VERSION=$(grep '#define PHP_AIKIDO_VERSION' lib/php-extension/include/php_aikido.h | awk -F'"' '{print $2}')
 
 dpkg --purge aikido-php-firewall
-alien -i --to-deb --scripts --keep-version /shared/aikido-php-firewall-$VERSION-1.x86_64.rpm
+alien -i --to-deb --scripts --keep-version /shared/aikido-php-firewall-$VERSION-1.$arch.rpm

--- a/tools/rpm_build.sh
+++ b/tools/rpm_build.sh
@@ -1,10 +1,12 @@
 rm -rf ~/rpmbuild
 rpmdev-setuptree
 
+arch=$(uname -m)
+
 PHP_VERSION=$(php -v | grep -oP 'PHP \K\d+\.\d+' | head -n 1)
 VERSION=$(grep '#define PHP_AIKIDO_VERSION' lib/php-extension/include/php_aikido.h | awk -F'"' '{print $2}')
 AIKIDO_INTERNALS_REPO=https://api.github.com/repos/AikidoSec/zen-internals
-AIKIDO_INTERNALS_LIB=libzen_internals_x86_64-unknown-linux-gnu.so
+AIKIDO_INTERNALS_LIB=libzen_internals_$arch-unknown-linux-gnu.so
 
 mkdir -p ~/rpmbuild/SOURCES/aikido-php-firewall-$VERSION
 

--- a/tools/rpm_install.sh
+++ b/tools/rpm_install.sh
@@ -1,4 +1,5 @@
+arch=$(uname -m)
 VERSION=$(grep '#define PHP_AIKIDO_VERSION' lib/php-extension/include/php_aikido.h | awk -F'"' '{print $2}')
 
-rpm -Uvh --oldpackage ~/rpmbuild/RPMS/x86_64/aikido-php-firewall-$VERSION-1.x86_64.rpm
-cp ~/rpmbuild/RPMS/x86_64/aikido-php-firewall-$VERSION-1.x86_64.rpm /shared
+rpm -Uvh --oldpackage ~/rpmbuild/RPMS/$arch/aikido-php-firewall-$VERSION-1.$arch.rpm
+cp ~/rpmbuild/RPMS/$arch/aikido-php-firewall-$VERSION-1.$arch.rpm /shared


### PR DESCRIPTION
- Added support for aarch64 for Centos (rpm) and Ubuntu(deb)
- Supports Ubuntu 22.04 and higher when arch = arm64
- Automated tests in the pipeline for both Ubuntu 22.04 and Ubuntu 24.04