### PR TITLE
Use amd64 as platform for sqlite sample app

### DIFF
--- a/sample-apps/sqlite-php-server/docker-compose.yml
+++ b/sample-apps/sqlite-php-server/docker-compose.yml
@@ -4,6 +4,7 @@ services:
   sqlite-php-server:
     container_name: php-server
     build: ../../
+    platform: linux/amd64
     ports:
       - "1337:1337"  
     volumes:


### PR DESCRIPTION
Otherwise the build process fails with the following error on macOS arm64:

```
 > [sqlite-php-server 14/14] RUN chmod +x /firewall-php/tools/sample_apps_build.sh && /firewall-php/tools/sample_apps_build.sh:
0.099 Configuring for:
0.099 PHP Api Version:         20210902
0.099 Zend Module Api No:      20210902
0.099 Zend Extension Api No:   420210902
0.830 go: downloading golang.org/x/net v0.33.0
0.850 go: downloading google.golang.org/protobuf v1.35.2
0.853 go: downloading golang.org/x/sys v0.28.0
1.147 go: downloading google.golang.org/genproto/googleapis/rpc v0.0.0-20241202173237-19429a94021a
1.235 go: downloading golang.org/x/text v0.21.0
2.178 go: downloading github.com/golang/protobuf v1.5.4
2.178 go: downloading github.com/stretchr/testify v1.9.0
2.192 go: downloading github.com/google/go-cmp v0.6.0
2.210 go: downloading go.opentelemetry.io/otel v1.32.0
2.211 go: downloading go.opentelemetry.io/otel/sdk/metric v1.32.0
2.415 go: downloading github.com/davecgh/go-spew v1.1.1
2.415 go: downloading github.com/pmezard/go-difflib v1.0.0
2.434 go: downloading gopkg.in/yaml.v3 v3.0.1
2.439 go: downloading go.opentelemetry.io/otel/metric v1.32.0
2.496 go: downloading go.opentelemetry.io/otel/sdk v1.32.0
2.524 go: downloading go.opentelemetry.io/otel/trace v1.32.0
2.547 go: downloading gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405
2.573 go: downloading github.com/go-logr/logr v1.4.2
2.573 go: downloading github.com/go-logr/stdr v1.2.2
2.589 go: downloading github.com/google/uuid v1.6.0
7.305 # runtime/cgo
7.305 gcc: error: unrecognized command line option '-m64'
------
failed to solve: process "/bin/sh -c chmod +x /firewall-php/tools/sample_apps_build.sh && /firewall-php/tools/sample_apps_build.sh" did not complete successfully: exit code: 1
```