### PR TITLE
Load AIKIDO-specific env from laravel even if cached

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,13 +37,13 @@ Prerequisites:
 #### For Red Hat-based Systems (RHEL, CentOS, Fedora)
 
 ```
-rpm -Uvh --oldpackage https://github.com/AikidoSec/firewall-php/releases/download/v1.0.116/aikido-php-firewall.x86_64.rpm
+rpm -Uvh --oldpackage https://github.com/AikidoSec/firewall-php/releases/download/v1.0.117/aikido-php-firewall.x86_64.rpm
 ```
 
 #### For Debian-based Systems (Debian, Ubuntu)
 
 ```
-curl -L -O https://github.com/AikidoSec/firewall-php/releases/download/v1.0.116/aikido-php-firewall.x86_64.deb
+curl -L -O https://github.com/AikidoSec/firewall-php/releases/download/v1.0.117/aikido-php-firewall.x86_64.deb
 dpkg -i -E ./aikido-php-firewall.x86_64.deb
 ```
 

--- a/docs/aws-elastic-beanstalk.md
+++ b/docs/aws-elastic-beanstalk.md
@@ -4,7 +4,7 @@
 ```
 commands:
   aikido-php-firewall:
-    command: "rpm -Uvh --oldpackage https://github.com/AikidoSec/firewall-php/releases/download/v1.0.116/aikido-php-firewall.x86_64.rpm"
+    command: "rpm -Uvh --oldpackage https://github.com/AikidoSec/firewall-php/releases/download/v1.0.117/aikido-php-firewall.x86_64.rpm"
     ignoreErrors: true
 
 files:

--- a/docs/fly-io.md
+++ b/docs/fly-io.md
@@ -32,7 +32,7 @@ Create a script to install the Aikido PHP Firewall during deployment:
 #!/usr/bin/env bash
 cd /tmp
 
-curl -L -O https://github.com/AikidoSec/firewall-php/releases/download/v1.0.116/aikido-php-firewall.x86_64.deb
+curl -L -O https://github.com/AikidoSec/firewall-php/releases/download/v1.0.117/aikido-php-firewall.x86_64.deb
 dpkg -i -E ./aikido-php-firewall.x86_64.deb
 ```
 

--- a/docs/laravel-forge.md
+++ b/docs/laravel-forge.md
@@ -21,7 +21,7 @@ cd /tmp
 
 # Install commands from the "Manual install" section below, based on your OS
 
-curl -L -O https://github.com/AikidoSec/firewall-php/releases/download/v1.0.116/aikido-php-firewall.x86_64.deb
+curl -L -O https://github.com/AikidoSec/firewall-php/releases/download/v1.0.117/aikido-php-firewall.x86_64.deb
 dpkg -i -E ./aikido-php-firewall.x86_64.deb
 
 # Restarting the php services in order to load the Aikido PHP Firewall

--- a/lib/agent/globals/constants.go
+++ b/lib/agent/globals/constants.go
@@ -1,7 +1,7 @@
 package globals
 
 const (
-	Version                             = "1.0.116"
+	Version                             = "1.0.117"
 	ConfigUpdatedAtMethod               = "GET"
 	ConfigUpdatedAtAPI                  = "/config"
 	ConfigAPIMethod                     = "GET"

--- a/lib/agent/go.mod
+++ b/lib/agent/go.mod
@@ -6,7 +6,7 @@ toolchain go1.23.3
 
 require (
 	github.com/stretchr/testify v1.9.0
-	google.golang.org/grpc v1.71.0
+	google.golang.org/grpc v1.71.1
 	google.golang.org/protobuf v1.36.4
 )
 

--- a/lib/agent/go.sum
+++ b/lib/agent/go.sum
@@ -24,6 +24,8 @@ google.golang.org/genproto/googleapis/rpc v0.0.0-20250115164207-1a7da9e5054f h1:
 google.golang.org/genproto/googleapis/rpc v0.0.0-20250115164207-1a7da9e5054f/go.mod h1:+2Yz8+CLJbIfL9z73EW45avw8Lmge3xVElCP9zEKi50=
 google.golang.org/grpc v1.71.0 h1:kF77BGdPTQ4/JZWMlb9VpJ5pa25aqvVqogsxNHHdeBg=
 google.golang.org/grpc v1.71.0/go.mod h1:H0GRtasmQOh9LkFoCPDu3ZrwUtD1YGE+b2vYBYd/8Ec=
+google.golang.org/grpc v1.71.1 h1:ffsFWr7ygTUscGPI0KKK6TLrGz0476KUvvsbqWK0rPI=
+google.golang.org/grpc v1.71.1/go.mod h1:H0GRtasmQOh9LkFoCPDu3ZrwUtD1YGE+b2vYBYd/8Ec=
 google.golang.org/protobuf v1.36.4 h1:6A3ZDJHn/eNqc1i+IdefRzy/9PokBTPvcqMySR7NNIM=
 google.golang.org/protobuf v1.36.4/go.mod h1:9fA7Ob0pmnwhb644+1+CVWFRbNajQ6iRojtC/QF5bRE=
 gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405 h1:yhCVgyC4o1eVCa2tZl7eS0r+SDo693bJlVdllGtEeKM=

--- a/lib/php-extension/Environment.cpp
+++ b/lib/php-extension/Environment.cpp
@@ -20,16 +20,91 @@ std::string GetPhpEnvVariable(const std::string& env_key) {
 std::string GetSystemEnvVariable(const std::string& env_key) {
     const char* env_value = getenv(env_key.c_str());
     if (!env_value) return "";
-    AIKIDO_LOG_DEBUG("env[%s] = %s\n", env_key.c_str(), env_value);
+    AIKIDO_LOG_DEBUG("sys_env[%s] = %s\n", env_key.c_str(), env_value);
     return env_value;
 }
 
-std::string GetEnvVariable(const std::string& env_key) {
-    std::string env_value = GetSystemEnvVariable(env_key);
-    if (env_value.empty()) {
-        return GetPhpEnvVariable(env_key);
+std::unordered_map<std::string, std::string> laravelEnv;
+bool laravelEnvLoaded = false;
+
+bool LoadLaravelEnvFileOnce() {
+    if (laravelEnvLoaded) {
+        return true;
     }
-    return env_value;
+
+    if (!request.IsServerVarLoaded()) {
+        return false;
+    }
+    std::string docRoot = request.GetVar("DOCUMENT_ROOT");
+    if (docRoot.empty()) {
+        return false;
+    }
+    std::string laravelEnvPath = docRoot + "/../.env";
+    std::ifstream envFile(laravelEnvPath);
+
+    if (!envFile.is_open()) {
+        return false;
+    }
+
+    std::string line;
+    while (std::getline(envFile, line)) {
+        // Skip empty lines and comments
+        if (line.empty() || line[0] == '#') {
+            continue;
+        }
+
+        // Check if line starts with env_key
+        if (line.substr(0, 6) == "AIKIDO") {
+            size_t pos = line.find('=');
+            if (pos != std::string::npos) {
+                std::string key = line.substr(0, pos);
+                std::string value = line.substr(pos + 1);
+                
+                // Trim whitespace from key and value
+                key.erase(0, key.find_first_not_of(" "));
+                key.erase(key.find_last_not_of(" ") + 1);
+                value.erase(0, value.find_first_not_of(" "));
+                value.erase(value.find_last_not_of(" ") + 1);
+                
+                // Remove quotes if present
+                if (value.length() >= 2 && 
+                    ((value.front() == '"' && value.back() == '"') ||
+                     (value.front() == '\'' && value.back() == '\''))) {
+                    value = value.substr(1, value.length() - 2);
+                }
+                laravelEnv[key] = value;
+            }
+        }
+    }
+    laravelEnvLoaded = true;
+    AIKIDO_LOG_DEBUG("Loaded Laravel env file: %s\n", laravelEnvPath.c_str());
+    return true;
+}
+
+std::string GetLaravelEnvVariable(const std::string& env_key) {
+    LoadLaravelEnvFileOnce();
+    if (laravelEnv.find(env_key) != laravelEnv.end()) {
+        AIKIDO_LOG_DEBUG("laravel_env[%s] = %s\n", env_key.c_str(), laravelEnv[env_key].c_str());
+        return laravelEnv[env_key];
+    }
+    return "";
+}
+
+using EnvGetterFn = std::string(*)(const std::string&);
+EnvGetterFn envGetters[] = {
+    &GetSystemEnvVariable,
+    &GetPhpEnvVariable,
+    &GetLaravelEnvVariable
+};
+
+std::string GetEnvVariable(const std::string& env_key) {
+    for (EnvGetterFn envGetter : envGetters) {
+        std::string env_value = envGetter(env_key);
+        if (!env_value.empty()) {
+            return env_value;
+        }
+    }
+    return "";
 }
 
 std::string GetEnvString(const std::string& env_key, const std::string default_value) {

--- a/lib/php-extension/Environment.cpp
+++ b/lib/php-extension/Environment.cpp
@@ -90,6 +90,12 @@ std::string GetLaravelEnvVariable(const std::string& env_key) {
     return "";
 }
 
+/*
+    Load env variables from the following sources (in this order):
+    - System environment variables
+    - PHP environment variables
+    - Laravel environment variables
+*/
 using EnvGetterFn = std::string(*)(const std::string&);
 EnvGetterFn envGetters[] = {
     &GetSystemEnvVariable,

--- a/lib/php-extension/Request.cpp
+++ b/lib/php-extension/Request.cpp
@@ -2,6 +2,10 @@
 
 Request request;
 
+bool Request::IsServerVarLoaded() {
+    return this->server != NULL;
+}
+
 bool Request::LoadServerVar() {
     if (this->server != NULL) {
         return true;

--- a/lib/php-extension/RequestProcessor.cpp
+++ b/lib/php-extension/RequestProcessor.cpp
@@ -174,6 +174,7 @@ void RequestProcessor::RequestShutdown() {
     // Unload the server variable at each request shutdown to force re-initialization
     // as PHP may change this between RINIT and RSHUTDOWN
     request.UnloadServerVar();
+    request.LoadServerVar();
     
     LoadConfigOnce();
     SendPostRequestEvent();

--- a/lib/php-extension/include/Includes.h
+++ b/lib/php-extension/include/Includes.h
@@ -19,6 +19,8 @@
 #include <unordered_map>
 #include <chrono>
 #include <spawn.h>
+#include <fstream>
+#include <iostream>
 
 #include "3rdparty/json.hpp"
 using namespace std;

--- a/lib/php-extension/include/Request.h
+++ b/lib/php-extension/include/Request.h
@@ -7,6 +7,8 @@ class Request {
    public:
     Request() = default;
 
+    bool IsServerVarLoaded();
+
     bool LoadServerVar();
 
     void UnloadServerVar();

--- a/lib/php-extension/include/php_aikido.h
+++ b/lib/php-extension/include/php_aikido.h
@@ -3,7 +3,7 @@
 extern zend_module_entry aikido_module_entry;
 #define phpext_aikido_ptr &aikido_module_entry
 
-#define PHP_AIKIDO_VERSION "1.0.116"
+#define PHP_AIKIDO_VERSION "1.0.117"
 
 #if defined(ZTS) && defined(COMPILE_DL_AIKIDO)
 ZEND_TSRMLS_CACHE_EXTERN()

--- a/lib/request-processor/globals/globals.go
+++ b/lib/request-processor/globals/globals.go
@@ -14,5 +14,5 @@ var CloudConfigMutex sync.Mutex
 var MiddlewareInstalled bool
 
 const (
-	Version = "1.0.116"
+	Version = "1.0.117"
 )

--- a/lib/request-processor/go.mod
+++ b/lib/request-processor/go.mod
@@ -7,7 +7,7 @@ toolchain go1.23.3
 require (
 	github.com/stretchr/testify v1.10.0
 	go4.org/netipx v0.0.0-20231129151722-fdeea329fbba
-	google.golang.org/grpc v1.71.0
+	google.golang.org/grpc v1.71.1
 	google.golang.org/protobuf v1.36.4
 )
 

--- a/lib/request-processor/go.sum
+++ b/lib/request-processor/go.sum
@@ -26,6 +26,8 @@ google.golang.org/genproto/googleapis/rpc v0.0.0-20250115164207-1a7da9e5054f h1:
 google.golang.org/genproto/googleapis/rpc v0.0.0-20250115164207-1a7da9e5054f/go.mod h1:+2Yz8+CLJbIfL9z73EW45avw8Lmge3xVElCP9zEKi50=
 google.golang.org/grpc v1.71.0 h1:kF77BGdPTQ4/JZWMlb9VpJ5pa25aqvVqogsxNHHdeBg=
 google.golang.org/grpc v1.71.0/go.mod h1:H0GRtasmQOh9LkFoCPDu3ZrwUtD1YGE+b2vYBYd/8Ec=
+google.golang.org/grpc v1.71.1 h1:ffsFWr7ygTUscGPI0KKK6TLrGz0476KUvvsbqWK0rPI=
+google.golang.org/grpc v1.71.1/go.mod h1:H0GRtasmQOh9LkFoCPDu3ZrwUtD1YGE+b2vYBYd/8Ec=
 google.golang.org/protobuf v1.36.4 h1:6A3ZDJHn/eNqc1i+IdefRzy/9PokBTPvcqMySR7NNIM=
 google.golang.org/protobuf v1.36.4/go.mod h1:9fA7Ob0pmnwhb644+1+CVWFRbNajQ6iRojtC/QF5bRE=
 gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405 h1:yhCVgyC4o1eVCa2tZl7eS0r+SDo693bJlVdllGtEeKM=

--- a/package/rpm/aikido.spec
+++ b/package/rpm/aikido.spec
@@ -1,5 +1,5 @@
 Name:           aikido-php-firewall
-Version:        1.0.116
+Version:        1.0.117
 Release:        1
 Summary:        Aikido PHP Extension
 License:        GPL

--- a/tools/dpkg_build.sh
+++ b/tools/dpkg_build.sh
@@ -8,3 +8,5 @@ mkdir deb-temp
 dpkg-deb -R temp-aikido-php-firewall-$VERSION-1.$arch.deb deb-temp/
 dpkg-deb -Zgzip -b deb-temp aikido-php-firewall-$VERSION-1.$arch.deb
 rm -rf deb-temp
+
+cp aikido-php-firewall-$VERSION-1.$arch.deb .devcontainer/shared/

--- a/tools/run_server_tests.py
+++ b/tools/run_server_tests.py
@@ -159,6 +159,7 @@ def main(root_tests_dir, test_lib_dir, specific_test=None, server="php-built-in"
 
         env = {
             "AIKIDO_LOG_LEVEL": "DEBUG" if debug else "ERROR",
+            "AIKIDO_DISK_LOGS": "1" if debug else "0",
             "AIKIDO_TOKEN": "AIK_RUNTIME_MOCK",
             "AIKIDO_ENDPOINT": f"http://localhost:{mock_port}/",
             "AIKIDO_REALTIME_ENDPOINT": f"http://localhost:{mock_port}/",


### PR DESCRIPTION
- If Laravel env variables are cached using `php artisan config:cache` they cannot be accessed anymore with any php / native functions
- The solution here loads directly the .env file and read the AIKIDO env directly from there