### PR TITLE
Fix flickering test and simplify generate data for limit tests

### DIFF
--- a/tests/server/test_domains_limits/test.py
+++ b/tests/server/test_domains_limits/test.py
@@ -5,12 +5,11 @@ from testlib import *
 
 
 def generate_domains():
-    generated_domains = set()
-    while len(generated_domains) < 2100:
-        domain_len = random.randint(20, 30)  # Random route length between 1-20 segments
-        domain = ''.join(random.choices('abcdefghijklmnopqrstuvwxyz0123456789-_', k=domain_len))
-        generated_domains.add(domain)
-    return list(generated_domains)
+    generated_domains = []
+    for i in range(2100):
+        domain = f"domain{i}"
+        generated_domains.append(domain)
+    return generated_domains
 
 
 def run_test():

--- a/tests/server/test_routes_limits/test.py
+++ b/tests/server/test_routes_limits/test.py
@@ -10,17 +10,11 @@ from testlib import *
 '''
 
 def generate_routes():
-    generated_routes = set()
-    while len(generated_routes) < 6000:
-        route_len = random.randint(1, 20)  # Random route length between 1-20 segments
-        route_parts = []
-        for j in range(route_len):
-            part_len = random.randint(3, 15)  # Random segment length between 3-15 chars
-            part = ''.join(random.choices('abcdefghijklmnopqrstuvwxyz0123456789-_', k=part_len))
-            route_parts.append(part)
-        route = '/' + '/'.join(route_parts)
-        generated_routes.add(route)
-    return list(generated_routes)
+    generated_routes = []
+    for i in range(6000):
+        route = f"/route{i}"
+        generated_routes.append(route)
+    return generated_routes
 
 def run_test():
     routes = generate_routes()

--- a/tests/server/test_user_limits/test.py
+++ b/tests/server/test_user_limits/test.py
@@ -5,12 +5,11 @@ from testlib import *
 
 
 def generate_users():
-    generated_users = set()
-    while len(generated_users) < 3500:
-        user_len = random.randint(1, 20)  # Random route length between 1-20 segments
-        user = ''.join(random.choices('abcdefghijklmnopqrstuvwxyz0123456789-_', k=user_len))
-        generated_users.add(user)
-    return list(generated_users)
+    generated_users = []
+    for i in range(3500):
+        user = f"user{i}"
+        generated_users.append(user)
+    return generated_users
 
 
 def run_test():


### PR DESCRIPTION
The test for routes sometimes fails:

```
Test stderr: Traceback (most recent call last):
  File "test.py", line 44, in <module>
    run_test()
  File "test.py", line 40, in run_test
    assert routes[-1] in paths, f"Route {routes[-1]} should be in reported paths"
AssertionError: Route /3xy2copptle/yll-/265/n89sadn_8/5_o4h_zw26a8f/v_a0nkuahmr/izduz19nbza9le/ydk2-yr3m/odbm77xj/zgw5u5azbkh7/-qz9/3w6mdkwx267/kgw/xd-s1/ahsdzingurr/l9-84_o/gd2wrtobgp/ljjo0iip3h/g4sfuocfg45dg should be in reported paths
```

It's because a route segment might contain enough entropy to be seen as a secret. So the segment would be replaced by :secret, thus the original route wouldn't be in the reported routes.

Let's improve the other tests too.