### PR TITLE
Updated build / release pipeline to re-enable support for Debian 11

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -13,7 +13,7 @@ jobs:
   build_libs:
     runs-on: ${{ matrix.os }}
     container:
-      image: ubuntu:20.04
+      image: debian:11
     strategy:
       matrix:
         os: [ ubuntu-24.04, ubuntu-24.04-arm ]
@@ -92,7 +92,7 @@ jobs:
 
   build_php_extension:
     runs-on: ${{ matrix.os }}
-    container: ubuntu:20.04
+    container: debian:11
     strategy:
       matrix:
         php_version: ['7.2', '7.3', '7.4', '8.0', '8.1', '8.2', '8.3', '8.4']
@@ -257,7 +257,7 @@ jobs:
   build_deb:
     runs-on: ${{ matrix.os }}
     container:
-      image: ubuntu:20.04
+      image: debian:11
     strategy:
       matrix:
         os: [ ubuntu-24.04, ubuntu-24.04-arm ]

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -27,16 +27,6 @@ jobs:
       run: echo "ARCH=$(uname -m)" >> $GITHUB_ENV
 
 
-    - uses: actions/setup-go@v5
-      with:
-        go-version: '1.22.0'
-        check-latest: true
-
-    - name: Install protoc
-      run: |
-        apt-get update
-        apt-get install -y software-properties-common
-        apt-get install -y protobuf-compiler protobuf-compiler-grpc
 
     # - name: Install dependencies
     #   run: |
@@ -44,7 +34,17 @@ jobs:
     #     apt-get install -y software-properties-common
     #     apt-get install -y golang-go protobuf-compiler protobuf-compiler-grpc
 
-        
+    - uses: actions/setup-go@v5
+      with:
+        go-version: '1.22.x'    
+        check-latest: true
+
+    - name: Install protoc
+      run: |
+        sudo apt-get update
+        sudo apt-get install -y protobuf-compiler
+  
+      
     - name: GO setup
       run: |
         go install google.golang.org/protobuf/cmd/protoc-gen-go@latest

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -36,8 +36,8 @@ jobs:
 
     - name: Install dependencies
       run: |
-        sudo apt-get update
-        sudo apt-get install -y protobuf-compiler
+        apt-get update
+        apt-get install -y protobuf-compiler curl
         protoc --version
 
     # Install a modern Go without actions/setup-go
@@ -45,8 +45,8 @@ jobs:
       run: |
         GO_VERSION=1.23.3
         curl -fsSL https://go.dev/dl/go${GO_VERSION}.linux-amd64.tar.gz -o /tmp/go.tgz
-        sudo rm -rf /usr/local/go
-        sudo tar -C /usr/local -xzf /tmp/go.tgz
+        rm -rf /usr/local/go
+        tar -C /usr/local -xzf /tmp/go.tgz
         echo "/usr/local/go/bin" >> "$GITHUB_PATH"
         echo "$HOME/go/bin" >> "$GITHUB_PATH"
         # Force module mode everywhere

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -133,7 +133,6 @@ jobs:
       env:
         PHPV: ${{ matrix.php_version }}
       run: |
-        set -euxo pipefail
         # Core + common dev extensions
         apt-get install -y --no-install-recommends \
           php$PHPV php$PHPV-cli php$PHPV-common php$PHPV-opcache \

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -122,29 +122,32 @@ jobs:
         echo "AIKIDO_VERSION=$AIKIDO_VERSION" >> $GITHUB_ENV
         echo "AIKIDO_ARTIFACT=aikido-extension-php-${{ matrix.php_version }}" >> $GITHUB_ENV
 
-    - name: Prepare APT (add ondrej/php PPA for multiple PHP versions)
+        - name: Clone php-src
+        run: |
+          git clone --depth=1 --branch ${{ matrix.php_version }} https://github.com/php/php-src.git
+          cd php-src
+          ./buildconf
+
+        - name: Configure & build PHP
+          run: |
+            cd php-src
+            ./configure \
+              --prefix=/usr/local \
+              --with-config-file-path=/usr/local/lib \
+              --with-config-file-scan-dir=/usr/local/etc/php/conf.d \
+              --enable-mbstring \
+              --enable-pcntl \
+              --enable-intl \
+              --with-curl \
+              --with-mysqli \
+              --with-openssl \
+              --with-zlib \
+              --with-zip
+            make -j"$(nproc)"
+            make install
+
+    - name: Verify PHP build
       run: |
-        apt-get update -y
-        apt-get install -y --no-install-recommends software-properties-common ca-certificates lsb-release apt-transport-https
-        add-apt-repository -y ppa:ondrej/php
-        apt-get update -y
-
-    - name: Install PHP ${{ matrix.php_version }} and dev extensions (no coverage)
-      env:
-        PHPV: ${{ matrix.php_version }}
-      run: |
-        # Core + common dev extensions
-        apt-get install -y --no-install-recommends \
-          php$PHPV php$PHPV-cli php$PHPV-common php$PHPV-opcache \
-          php$PHPV-curl php$PHPV-mysql php$PHPV-mbstring php$PHPV-xml php$PHPV-zip \
-          php$PHPV-dev php$PHPV-pear
-
-        # Make this PHP the default "php"
-        update-alternatives --set php /usr/bin/php$PHPV
-        # (Optional but handy for building/ext tooling)
-        if [[ -x /usr/bin/phpize$PHPV ]]; then update-alternatives --set phpize /usr/bin/phpize$PHPV; fi
-        if [[ -x /usr/bin/php-config$PHPV ]]; then update-alternatives --set php-config /usr/bin/php-config$PHPV; fi
-
         php -v
         php -m | grep -E 'curl|mysqli' || (echo "Required extensions missing" && php -m && exit 1)
 

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -13,7 +13,7 @@ jobs:
   build_libs:
     runs-on: ${{ matrix.os }}
     container:
-      image: debian:11
+      image: ubuntu:20.04
     strategy:
       matrix:
         os: [ ubuntu-24.04, ubuntu-24.04-arm ]
@@ -26,42 +26,14 @@ jobs:
     - name: Get Arch
       run: echo "ARCH=$(uname -m)" >> $GITHUB_ENV
 
-
-
-    # - name: Install dependencies
-    #   run: |
-    #     apt-get update
-    #     apt-get install -y software-properties-common
-    #     apt-get install -y golang-go protobuf-compiler protobuf-compiler-grpc
-
     - name: Install dependencies
       run: |
         apt-get update
-        apt-get install -y protobuf-compiler curl git ca-certificates
-        protoc --version
-    
-    # Install Go matching the container architecture (amd64/arm64)
-    - name: Install Go (tarball)
-      shell: bash
-      run: |
-        set -euo pipefail
-        GO_VERSION=1.23.3
-        uname_m="$(uname -m)"
-        case "$uname_m" in
-          x86_64)  GO_ARCH=amd64 ;;
-          aarch64) GO_ARCH=arm64 ;;
-          arm64)   GO_ARCH=arm64 ;;
-          *) echo "Unsupported arch: $uname_m"; exit 1 ;;
-        esac
-        curl -fsSL "https://go.dev/dl/go${GO_VERSION}.linux-${GO_ARCH}.tar.gz" -o /tmp/go.tgz
-        rm -rf /usr/local/go
-        tar -C /usr/local -xzf /tmp/go.tgz
-        echo "/usr/local/go/bin" >> "$GITHUB_PATH"
-        echo "$HOME/go/bin" >> "$GITHUB_PATH"
-        /usr/local/go/bin/go env -w GO111MODULE=on
-        /usr/local/go/bin/go version && /usr/local/go/bin/go env
+        apt-get install -y software-properties-common
+        add-apt-repository ppa:longsleep/golang-backports
+        apt-get update
+        apt-get install -y golang-go protobuf-compiler protobuf-compiler-grpc
 
-   
     - name: GO setup
       run: |
         go install google.golang.org/protobuf/cmd/protoc-gen-go@latest
@@ -69,7 +41,6 @@ jobs:
         echo "$HOME/go/bin" >> $GITHUB_PATH
 
     - name: Get Aikido version
-      shell: bash
       run: |
         AIKIDO_VERSION=$(grep '#define PHP_AIKIDO_VERSION' lib/php-extension/include/php_aikido.h | awk -F'"' '{print $2}')
         echo $AIKIDO_VERSION
@@ -77,7 +48,6 @@ jobs:
         echo "AIKIDO_INTERNALS_REPO=https://api.github.com/repos/AikidoSec/zen-internals" >> $GITHUB_ENV
 
     - name: Build Aikido Agent
-      shell: bash
       run: |
         cd lib
         protoc --go_out=agent --go-grpc_out=agent ipc.proto
@@ -122,7 +92,7 @@ jobs:
 
   build_php_extension:
     runs-on: ${{ matrix.os }}
-    container: debian:11
+    container: ubuntu:20.04
     strategy:
       matrix:
         php_version: ['7.2', '7.3', '7.4', '8.0', '8.1', '8.2', '8.3', '8.4']
@@ -158,7 +128,9 @@ jobs:
         php-version: ${{ matrix.php_version }}
         extensions: curl, mysqli
         coverage: none
-
+      env:
+        runner: self-hosted
+        
     - name: Check PHP setup
       run: |
         which php
@@ -287,7 +259,7 @@ jobs:
   build_deb:
     runs-on: ${{ matrix.os }}
     container:
-      image: debian:11
+      image: ubuntu:20.04
     strategy:
       matrix:
         os: [ ubuntu-24.04, ubuntu-24.04-arm ]
@@ -514,6 +486,8 @@ jobs:
           php-version: ${{ matrix.php_version }}
           extensions: curl, sqlite3, mysqli
           coverage: none
+        env:
+          runner: self-hosted
 
       - name: Test MySQL connection with mysqli
         run: |

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -124,7 +124,7 @@ jobs:
 
     - name: Clone php-src
       run: |
-        git clone --depth=1 --branch ${{ matrix.php_version }} https://github.com/php/php-src.git
+        git clone --depth=1 --branch PHP-${{ matrix.php_version }} https://github.com/php/php-src.git
         cd php-src
         ./buildconf
 

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -35,7 +35,8 @@ jobs:
     - name: Install protoc
       run: |
         apt-get update
-        apt-get install -y protobuf-compiler
+        apt-get install -y software-properties-common
+        apt-get install -y protobuf-compiler protobuf-compiler-grpc
 
     # - name: Install dependencies
     #   run: |

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -92,7 +92,7 @@ jobs:
 
   build_php_extension:
     runs-on: ${{ matrix.os }}
-    container: ubuntu:22.04
+    container: ubuntu:20.04
     strategy:
       matrix:
         php_version: ['7.2', '7.3', '7.4', '8.0', '8.1', '8.2', '8.3', '8.4']

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -34,17 +34,25 @@ jobs:
     #     apt-get install -y software-properties-common
     #     apt-get install -y golang-go protobuf-compiler protobuf-compiler-grpc
 
-    - uses: actions/setup-go@v5
-      with:
-        go-version: '1.23.3'    
-        check-latest: true
-
-    - name: Install protoc
+    - name: Install dependencies
       run: |
-        apt-get update
-        apt-get install -y protobuf-compiler protobuf-compiler-grpc software-properties-common
-  
-      
+        sudo apt-get update
+        sudo apt-get install -y protobuf-compiler
+        protoc --version
+
+    # Install a modern Go without actions/setup-go
+    - name: Install Go (tarball)
+      run: |
+        GO_VERSION=1.23.3
+        curl -fsSL https://go.dev/dl/go${GO_VERSION}.linux-amd64.tar.gz -o /tmp/go.tgz
+        sudo rm -rf /usr/local/go
+        sudo tar -C /usr/local -xzf /tmp/go.tgz
+        echo "/usr/local/go/bin" >> "$GITHUB_PATH"
+        echo "$HOME/go/bin" >> "$GITHUB_PATH"
+        # Force module mode everywhere
+        /usr/local/go/bin/go env -w GO111MODULE=on
+        /usr/local/go/bin/go version
+   
     - name: GO setup
       run: |
         go install google.golang.org/protobuf/cmd/protoc-gen-go@latest

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -263,7 +263,7 @@ jobs:
           mv ~/rpmbuild/RPMS/${{ env.ARCH }}/${{ env.AIKIDO_ARTIFACT }} ~/rpmbuild/RPMS/${{ env.ARCH }}/${{ env.AIKIDO_ARTIFACT_RELEASE }}
 
       - name: Check rpm dependencies
-        if: matrix.os == 'ubuntu-22.04'
+        if: matrix.os == 'ubuntu-24.04'
         run: |
           yum deplist ~/rpmbuild/RPMS/${{ env.ARCH }}/${{ env.AIKIDO_ARTIFACT_RELEASE }} | grep -E "GLIBC_2.32|GLIBC_2.34|GLIBCXX_3.4.29" && exit 1 || exit 0
 

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -34,8 +34,8 @@ jobs:
 
     - name: Install protoc
       run: |
-        sudo apt-get update
-        sudo apt-get install -y protobuf-compiler
+        apt-get update
+        apt-get install -y protobuf-compiler
 
     # - name: Install dependencies
     #   run: |

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -36,13 +36,13 @@ jobs:
 
     - uses: actions/setup-go@v5
       with:
-        go-version: '1.22.x'    
+        go-version: '1.23.3'    
         check-latest: true
 
     - name: Install protoc
       run: |
         apt-get update
-        apt-get install -y protobuf-compiler
+        apt-get install -y protobuf-compiler protobuf-compiler-grpc software-properties-common
   
       
     - name: GO setup

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -136,7 +136,7 @@ jobs:
     - name: Clone php-src
       run: |
         cd php-src
-        ./buildconf
+        ./buildconf --force
 
     - name: Configure & build PHP
       run: |

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -13,7 +13,7 @@ jobs:
   build_libs:
     runs-on: ${{ matrix.os }}
     container:
-      image: ubuntu:20.04
+      image: ubuntu:22.04
     strategy:
       matrix:
         os: [ ubuntu-24.04, ubuntu-24.04-arm ]
@@ -92,7 +92,7 @@ jobs:
 
   build_php_extension:
     runs-on: ${{ matrix.os }}
-    container: ubuntu:20.04
+    container: ubuntu:22.04
     strategy:
       matrix:
         php_version: ['7.2', '7.3', '7.4', '8.0', '8.1', '8.2', '8.3', '8.4']
@@ -260,7 +260,7 @@ jobs:
   build_deb:
     runs-on: ${{ matrix.os }}
     container:
-      image: ubuntu:20.04
+      image: ubuntu:22.04
     strategy:
       matrix:
         os: [ ubuntu-24.04, ubuntu-24.04-arm ]

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -42,6 +42,7 @@ jobs:
     
     # Install Go matching the container architecture (amd64/arm64)
     - name: Install Go (tarball)
+      shell: bash
       run: |
         set -euo pipefail
         GO_VERSION=1.23.3
@@ -68,6 +69,7 @@ jobs:
         echo "$HOME/go/bin" >> $GITHUB_PATH
 
     - name: Get Aikido version
+      shell: bash
       run: |
         AIKIDO_VERSION=$(grep '#define PHP_AIKIDO_VERSION' lib/php-extension/include/php_aikido.h | awk -F'"' '{print $2}')
         echo $AIKIDO_VERSION
@@ -75,6 +77,7 @@ jobs:
         echo "AIKIDO_INTERNALS_REPO=https://api.github.com/repos/AikidoSec/zen-internals" >> $GITHUB_ENV
 
     - name: Build Aikido Agent
+      shell: bash
       run: |
         cd lib
         protoc --go_out=agent --go-grpc_out=agent ipc.proto

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -517,9 +517,6 @@ jobs:
           php-version: ${{ matrix.php_version }}
           extensions: curl, sqlite3, mysqli
           coverage: none
-        env:
-          runner: self-hosted
-          debug: true
 
       - name: Test MySQL connection with mysqli
         run: |

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -110,7 +110,10 @@ jobs:
         ln -fs /usr/share/zoneinfo/Etc/UTC /etc/localtime
         echo "Etc/UTC" > /etc/timezone
         DEBIAN_FRONTEND=noninteractive dpkg-reconfigure -f noninteractive tzdata
-        apt-get install -y --no-install-recommends build-essential autoconf bison re2c pkg-config libxml2-dev libsqlite3-dev libcurl4-openssl-dev libssl-dev libzip-dev libonig-dev libjpeg-dev libpng-dev libwebp-dev libicu-dev libreadline-dev libxslt1-dev default-libmysqlclient-dev git wget tar
+        apt-get install -y --no-install-recommends build-essential autoconf bison re2c pkg-config libxml2-dev libsqlite3-dev libcurl4-openssl-dev libssl-dev libzip-dev libonig-dev libjpeg-dev libpng-dev libwebp-dev libicu-dev libreadline-dev libxslt1-dev default-libmysqlclient-dev git wget tar ca-certificates
+        update-ca-certificates
+        git config --global http.sslCAInfo /etc/ssl/certs/ca-certificates.crt
+        git config --global http.sslVerify true
 
     - name: Get Arch
       run: echo "ARCH=$(uname -m)" >> $GITHUB_ENV

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -122,9 +122,16 @@ jobs:
         echo "AIKIDO_VERSION=$AIKIDO_VERSION" >> $GITHUB_ENV
         echo "AIKIDO_ARTIFACT=aikido-extension-php-${{ matrix.php_version }}" >> $GITHUB_ENV
 
+    - name: Checkout php-src
+      uses: actions/checkout@v4
+      with:
+        repository: php/php-src
+        ref: PHP-${{ matrix.php_version }}
+        path: php-src
+        fetch-depth: 1
+
     - name: Clone php-src
       run: |
-        git clone --depth=1 --branch PHP-${{ matrix.php_version }} https://github.com/php/php-src.git
         cd php-src
         ./buildconf
 

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -110,7 +110,7 @@ jobs:
         ln -fs /usr/share/zoneinfo/Etc/UTC /etc/localtime
         echo "Etc/UTC" > /etc/timezone
         DEBIAN_FRONTEND=noninteractive dpkg-reconfigure -f noninteractive tzdata
-        apt-get install -y autoconf bison re2c libxml2-dev libssl-dev libcurl4-gnutls-dev
+        apt-get install -y --no-install-recommends build-essential autoconf bison re2c pkg-config libxml2-dev libsqlite3-dev libcurl4-openssl-dev libssl-dev libzip-dev libonig-dev libjpeg-dev libpng-dev libwebp-dev libicu-dev libreadline-dev libxslt1-dev default-libmysqlclient-dev git wget tar
 
     - name: Get Arch
       run: echo "ARCH=$(uname -m)" >> $GITHUB_ENV

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -29,7 +29,7 @@ jobs:
 
     - uses: actions/setup-go@v5
       with:
-        go-version: '1.25.0'
+        go-version: '1.22.0'
         check-latest: true
 
     - name: Install protoc

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -37,21 +37,29 @@ jobs:
     - name: Install dependencies
       run: |
         apt-get update
-        apt-get install -y protobuf-compiler curl
+        apt-get install -y protobuf-compiler curl git ca-certificates
         protoc --version
-
-    # Install a modern Go without actions/setup-go
+    
+    # Install Go matching the container architecture (amd64/arm64)
     - name: Install Go (tarball)
       run: |
+        set -euo pipefail
         GO_VERSION=1.23.3
-        curl -fsSL https://go.dev/dl/go${GO_VERSION}.linux-amd64.tar.gz -o /tmp/go.tgz
+        uname_m="$(uname -m)"
+        case "$uname_m" in
+          x86_64)  GO_ARCH=amd64 ;;
+          aarch64) GO_ARCH=arm64 ;;
+          arm64)   GO_ARCH=arm64 ;;
+          *) echo "Unsupported arch: $uname_m"; exit 1 ;;
+        esac
+        curl -fsSL "https://go.dev/dl/go${GO_VERSION}.linux-${GO_ARCH}.tar.gz" -o /tmp/go.tgz
         rm -rf /usr/local/go
         tar -C /usr/local -xzf /tmp/go.tgz
         echo "/usr/local/go/bin" >> "$GITHUB_PATH"
         echo "$HOME/go/bin" >> "$GITHUB_PATH"
-        # Force module mode everywhere
         /usr/local/go/bin/go env -w GO111MODULE=on
-        /usr/local/go/bin/go version
+        /usr/local/go/bin/go version && /usr/local/go/bin/go env
+
    
     - name: GO setup
       run: |

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -275,7 +275,6 @@ jobs:
           mv ~/rpmbuild/RPMS/${{ env.ARCH }}/${{ env.AIKIDO_ARTIFACT }} ~/rpmbuild/RPMS/${{ env.ARCH }}/${{ env.AIKIDO_ARTIFACT_RELEASE }}
 
       - name: Check rpm dependencies
-        if: matrix.os == 'ubuntu-24.04'
         run: |
           yum deplist ~/rpmbuild/RPMS/${{ env.ARCH }}/${{ env.AIKIDO_ARTIFACT_RELEASE }} | grep -E "GLIBC_2.32|GLIBC_2.34|GLIBCXX_3.4.29" && exit 1 || exit 0
 

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -28,14 +28,36 @@ jobs:
 
     - name: Install dependencies
       run: |
+        set -euo pipefail
+        # Backports for newer Go on bullseye
+        echo "deb http://deb.debian.org/debian bullseye-backports main" | \
+          tee /etc/apt/sources.list.d/bullseye-backports.list
+          
         apt-get update
-        apt-get install gnupg -y
-        apt-get install -y software-properties-common
-        add-apt-repository ppa:longsleep/golang-backports
-        apt-get update
-        apt-get install -y golang-go protobuf-compiler protobuf-compiler-grpc
-       
+        apt-get install -y --no-install-recommends \
+          ca-certificates curl git gnupg build-essential pkg-config
 
+        # Go from backports
+        apt-get -t bullseye-backports install -y golang-go
+
+        # Protobuf compiler (protoc)
+        apt-get install -y --no-install-recommends protobuf-compiler
+
+        # Go plugins for protoc (avoids distro-specific packages)
+        export GOPATH=/root/go
+        export PATH=$PATH:/usr/local/go/bin:$GOPATH/bin
+
+        go version
+        protoc --version
+
+        # Install protoc-gen-go and protoc-gen-go-grpc
+        go install google.golang.org/protobuf/cmd/protoc-gen-go@v1.34.1
+        go install google.golang.org/grpc/cmd/protoc-gen-go-grpc@v1.4.0
+
+        # Make them available system-wide
+        install -m 0755 -D "$GOPATH/bin/protoc-gen-go" /usr/local/bin/protoc-gen-go
+        install -m 0755 -D "$GOPATH/bin/protoc-gen-go-grpc" /usr/local/bin/protoc-gen-go-grpc
+        
     - name: GO setup
       run: |
         go install google.golang.org/protobuf/cmd/protoc-gen-go@latest

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -122,29 +122,29 @@ jobs:
         echo "AIKIDO_VERSION=$AIKIDO_VERSION" >> $GITHUB_ENV
         echo "AIKIDO_ARTIFACT=aikido-extension-php-${{ matrix.php_version }}" >> $GITHUB_ENV
 
-        - name: Clone php-src
-        run: |
-          git clone --depth=1 --branch ${{ matrix.php_version }} https://github.com/php/php-src.git
-          cd php-src
-          ./buildconf
+    - name: Clone php-src
+      run: |
+        git clone --depth=1 --branch ${{ matrix.php_version }} https://github.com/php/php-src.git
+        cd php-src
+        ./buildconf
 
-        - name: Configure & build PHP
-          run: |
-            cd php-src
-            ./configure \
-              --prefix=/usr/local \
-              --with-config-file-path=/usr/local/lib \
-              --with-config-file-scan-dir=/usr/local/etc/php/conf.d \
-              --enable-mbstring \
-              --enable-pcntl \
-              --enable-intl \
-              --with-curl \
-              --with-mysqli \
-              --with-openssl \
-              --with-zlib \
-              --with-zip
-            make -j"$(nproc)"
-            make install
+    - name: Configure & build PHP
+      run: |
+        cd php-src
+        ./configure \
+          --prefix=/usr/local \
+          --with-config-file-path=/usr/local/lib \
+          --with-config-file-scan-dir=/usr/local/etc/php/conf.d \
+          --enable-mbstring \
+          --enable-pcntl \
+          --enable-intl \
+          --with-curl \
+          --with-mysqli \
+          --with-openssl \
+          --with-zlib \
+          --with-zip
+        make -j"$(nproc)"
+        make install
 
     - name: Verify PHP build
       run: |

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -33,6 +33,7 @@ jobs:
         add-apt-repository ppa:longsleep/golang-backports
         apt-get update
         apt-get install -y golang-go protobuf-compiler protobuf-compiler-grpc
+        apt-get install gnupg
 
     - name: GO setup
       run: |

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -124,10 +124,10 @@ jobs:
 
     - name: Prepare APT (add ondrej/php PPA for multiple PHP versions)
       run: |
-        sudo apt-get update -y
-        sudo apt-get install -y --no-install-recommends software-properties-common ca-certificates lsb-release apt-transport-https
-        sudo add-apt-repository -y ppa:ondrej/php
-        sudo apt-get update -y
+        apt-get update -y
+        apt-get install -y --no-install-recommends software-properties-common ca-certificates lsb-release apt-transport-https
+        add-apt-repository -y ppa:ondrej/php
+        apt-get update -y
 
     - name: Install PHP ${{ matrix.php_version }} and dev extensions (no coverage)
       env:
@@ -135,16 +135,16 @@ jobs:
       run: |
         set -euxo pipefail
         # Core + common dev extensions
-        sudo apt-get install -y --no-install-recommends \
+        apt-get install -y --no-install-recommends \
           php$PHPV php$PHPV-cli php$PHPV-common php$PHPV-opcache \
           php$PHPV-curl php$PHPV-mysql php$PHPV-mbstring php$PHPV-xml php$PHPV-zip \
           php$PHPV-dev php$PHPV-pear
 
         # Make this PHP the default "php"
-        sudo update-alternatives --set php /usr/bin/php$PHPV
+        update-alternatives --set php /usr/bin/php$PHPV
         # (Optional but handy for building/ext tooling)
-        if [[ -x /usr/bin/phpize$PHPV ]]; then sudo update-alternatives --set phpize /usr/bin/phpize$PHPV; fi
-        if [[ -x /usr/bin/php-config$PHPV ]]; then sudo update-alternatives --set php-config /usr/bin/php-config$PHPV; fi
+        if [[ -x /usr/bin/phpize$PHPV ]]; then update-alternatives --set phpize /usr/bin/phpize$PHPV; fi
+        if [[ -x /usr/bin/php-config$PHPV ]]; then update-alternatives --set php-config /usr/bin/php-config$PHPV; fi
 
         php -v
         php -m | grep -E 'curl|mysqli' || (echo "Required extensions missing" && php -m && exit 1)

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -13,7 +13,7 @@ jobs:
   build_libs:
     runs-on: ${{ matrix.os }}
     container:
-      image: ubuntu:22.04
+      image: ubuntu:20.04
     strategy:
       matrix:
         os: [ ubuntu-24.04, ubuntu-24.04-arm ]

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -130,6 +130,7 @@ jobs:
         coverage: none
       env:
         runner: self-hosted
+        debug: true
         
     - name: Check PHP setup
       run: |
@@ -488,6 +489,7 @@ jobs:
           coverage: none
         env:
           runner: self-hosted
+          debug: true
 
       - name: Test MySQL connection with mysqli
         run: |

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -28,35 +28,10 @@ jobs:
 
     - name: Install dependencies
       run: |
-        set -euo pipefail
-        # Backports for newer Go on bullseye
-        echo "deb http://deb.debian.org/debian bullseye-backports main" | \
-          tee /etc/apt/sources.list.d/bullseye-backports.list
-          
         apt-get update
-        apt-get install -y --no-install-recommends \
-          ca-certificates curl git gnupg build-essential pkg-config
+        apt-get install -y software-properties-common
+        apt-get install -y golang-go protobuf-compiler protobuf-compiler-grpc
 
-        # Go from backports
-        apt-get -t bullseye-backports install -y golang-go
-
-        # Protobuf compiler (protoc)
-        apt-get install -y --no-install-recommends protobuf-compiler
-
-        # Go plugins for protoc (avoids distro-specific packages)
-        export GOPATH=/root/go
-        export PATH=$PATH:/usr/local/go/bin:$GOPATH/bin
-
-        go version
-        protoc --version
-
-        # Install protoc-gen-go and protoc-gen-go-grpc
-        go install google.golang.org/protobuf/cmd/protoc-gen-go@v1.34.1
-        go install google.golang.org/grpc/cmd/protoc-gen-go-grpc@v1.4.0
-
-        # Make them available system-wide
-        install -m 0755 -D "$GOPATH/bin/protoc-gen-go" /usr/local/bin/protoc-gen-go
-        install -m 0755 -D "$GOPATH/bin/protoc-gen-go-grpc" /usr/local/bin/protoc-gen-go-grpc
         
     - name: GO setup
       run: |

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -29,11 +29,12 @@ jobs:
     - name: Install dependencies
       run: |
         apt-get update
+        apt-get install gnupg
         apt-get install -y software-properties-common
         add-apt-repository ppa:longsleep/golang-backports
         apt-get update
         apt-get install -y golang-go protobuf-compiler protobuf-compiler-grpc
-        apt-get install gnupg
+       
 
     - name: GO setup
       run: |

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -41,8 +41,8 @@ jobs:
 
     - name: Install protoc
       run: |
-        sudo apt-get update
-        sudo apt-get install -y protobuf-compiler
+        apt-get update
+        apt-get install -y protobuf-compiler
   
       
     - name: GO setup

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -29,7 +29,7 @@ jobs:
     - name: Install dependencies
       run: |
         apt-get update
-        apt-get install gnupg
+        apt-get install gnupg -y
         apt-get install -y software-properties-common
         add-apt-repository ppa:longsleep/golang-backports
         apt-get update

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -13,7 +13,7 @@ jobs:
   build_libs:
     runs-on: ${{ matrix.os }}
     container:
-      image: ubuntu:22.04
+      image: ubuntu:20.04
     strategy:
       matrix:
         os: [ ubuntu-24.04, ubuntu-24.04-arm ]
@@ -92,7 +92,7 @@ jobs:
 
   build_php_extension:
     runs-on: ${{ matrix.os }}
-    container: ubuntu:22.04
+    container: ubuntu:20.04
     strategy:
       matrix:
         php_version: ['7.2', '7.3', '7.4', '8.0', '8.1', '8.2', '8.3', '8.4']
@@ -257,7 +257,7 @@ jobs:
   build_deb:
     runs-on: ${{ matrix.os }}
     container:
-      image: ubuntu:22.04
+      image: ubuntu:20.04
     strategy:
       matrix:
         os: [ ubuntu-24.04, ubuntu-24.04-arm ]

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -26,11 +26,22 @@ jobs:
     - name: Get Arch
       run: echo "ARCH=$(uname -m)" >> $GITHUB_ENV
 
-    - name: Install dependencies
+
+    - uses: actions/setup-go@v5
+      with:
+        go-version: '1.25.0'
+        check-latest: true
+
+    - name: Install protoc
       run: |
-        apt-get update
-        apt-get install -y software-properties-common
-        apt-get install -y golang-go protobuf-compiler protobuf-compiler-grpc
+        sudo apt-get update
+        sudo apt-get install -y protobuf-compiler
+
+    # - name: Install dependencies
+    #   run: |
+    #     apt-get update
+    #     apt-get install -y software-properties-common
+    #     apt-get install -y golang-go protobuf-compiler protobuf-compiler-grpc
 
         
     - name: GO setup

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -122,15 +122,33 @@ jobs:
         echo "AIKIDO_VERSION=$AIKIDO_VERSION" >> $GITHUB_ENV
         echo "AIKIDO_ARTIFACT=aikido-extension-php-${{ matrix.php_version }}" >> $GITHUB_ENV
 
-    - name: Setup PHP
-      uses: shivammathur/setup-php@27853eb8b46dc01c33bf9fef67d98df2683c3be2 # v2
-      with:
-        php-version: ${{ matrix.php_version }}
-        extensions: curl, mysqli
-        coverage: none
+    - name: Prepare APT (add ondrej/php PPA for multiple PHP versions)
+      run: |
+        sudo apt-get update -y
+        sudo apt-get install -y --no-install-recommends software-properties-common ca-certificates lsb-release apt-transport-https
+        sudo add-apt-repository -y ppa:ondrej/php
+        sudo apt-get update -y
+
+    - name: Install PHP ${{ matrix.php_version }} and dev extensions (no coverage)
       env:
-        runner: self-hosted
-        debug: true
+        PHPV: ${{ matrix.php_version }}
+      run: |
+        set -euxo pipefail
+        # Core + common dev extensions
+        sudo apt-get install -y --no-install-recommends \
+          php$PHPV php$PHPV-cli php$PHPV-common php$PHPV-opcache \
+          php$PHPV-curl php$PHPV-mysql php$PHPV-mbstring php$PHPV-xml php$PHPV-zip \
+          php$PHPV-dev php$PHPV-pear
+
+        # Make this PHP the default "php"
+        sudo update-alternatives --set php /usr/bin/php$PHPV
+        # (Optional but handy for building/ext tooling)
+        if [[ -x /usr/bin/phpize$PHPV ]]; then sudo update-alternatives --set phpize /usr/bin/phpize$PHPV; fi
+        if [[ -x /usr/bin/php-config$PHPV ]]; then sudo update-alternatives --set php-config /usr/bin/php-config$PHPV; fi
+
+        php -v
+        php -m | grep -E 'curl|mysqli' || (echo "Required extensions missing" && php -m && exit 1)
+
         
     - name: Check PHP setup
       run: |

--- a/README.md
+++ b/README.md
@@ -38,25 +38,25 @@ Prerequisites:
 
 ##### x86_64
 ```
-rpm -Uvh --oldpackage https://github.com/AikidoSec/firewall-php/releases/download/v1.3.0/aikido-php-firewall.x86_64.rpm
+rpm -Uvh --oldpackage https://github.com/AikidoSec/firewall-php/releases/download/v1.3.1/aikido-php-firewall.x86_64.rpm
 ```
 
 ##### arm64 / aarch64
 ```
-rpm -Uvh --oldpackage https://github.com/AikidoSec/firewall-php/releases/download/v1.3.0/aikido-php-firewall.aarch64.rpm
+rpm -Uvh --oldpackage https://github.com/AikidoSec/firewall-php/releases/download/v1.3.1/aikido-php-firewall.aarch64.rpm
 ```
 
 #### For Debian-based Systems (Debian, Ubuntu)
 
 ##### x86_64
 ```
-curl -L -O https://github.com/AikidoSec/firewall-php/releases/download/v1.3.0/aikido-php-firewall.x86_64.deb
+curl -L -O https://github.com/AikidoSec/firewall-php/releases/download/v1.3.1/aikido-php-firewall.x86_64.deb
 dpkg -i -E ./aikido-php-firewall.x86_64.deb
 ```
 
 ##### arm64 / aarch64
 ```
-curl -L -O https://github.com/AikidoSec/firewall-php/releases/download/v1.3.0/aikido-php-firewall.aarch64.deb
+curl -L -O https://github.com/AikidoSec/firewall-php/releases/download/v1.3.1/aikido-php-firewall.aarch64.deb
 dpkg -i -E ./aikido-php-firewall.aarch64.deb
 ```
 

--- a/docs/aws-elastic-beanstalk.md
+++ b/docs/aws-elastic-beanstalk.md
@@ -4,7 +4,7 @@
 ```
 commands:
   aikido-php-firewall:
-    command: "rpm -Uvh --oldpackage https://github.com/AikidoSec/firewall-php/releases/download/v1.3.0/aikido-php-firewall.x86_64.rpm"
+    command: "rpm -Uvh --oldpackage https://github.com/AikidoSec/firewall-php/releases/download/v1.3.1/aikido-php-firewall.x86_64.rpm"
     ignoreErrors: true
 
 files:

--- a/docs/fly-io.md
+++ b/docs/fly-io.md
@@ -32,7 +32,7 @@ Create a script to install the Aikido PHP Firewall during deployment:
 #!/usr/bin/env bash
 cd /tmp
 
-curl -L -O https://github.com/AikidoSec/firewall-php/releases/download/v1.3.0/aikido-php-firewall.x86_64.deb
+curl -L -O https://github.com/AikidoSec/firewall-php/releases/download/v1.3.1/aikido-php-firewall.x86_64.deb
 dpkg -i -E ./aikido-php-firewall.x86_64.deb
 ```
 

--- a/docs/laravel-forge.md
+++ b/docs/laravel-forge.md
@@ -21,7 +21,7 @@ cd /tmp
 
 # Install commands from the "Manual install" section below, based on your OS
 
-curl -L -O https://github.com/AikidoSec/firewall-php/releases/download/v1.3.0/aikido-php-firewall.x86_64.deb
+curl -L -O https://github.com/AikidoSec/firewall-php/releases/download/v1.3.1/aikido-php-firewall.x86_64.deb
 dpkg -i -E ./aikido-php-firewall.x86_64.deb
 
 # Restarting the php services in order to load the Aikido PHP Firewall

--- a/lib/agent/globals/constants.go
+++ b/lib/agent/globals/constants.go
@@ -1,7 +1,7 @@
 package globals
 
 const (
-	Version                             = "1.3.0"
+	Version                             = "1.3.1"
 	ConfigUpdatedAtMethod               = "GET"
 	ConfigUpdatedAtAPI                  = "/config"
 	ConfigAPIMethod                     = "GET"

--- a/lib/php-extension/include/php_aikido.h
+++ b/lib/php-extension/include/php_aikido.h
@@ -3,7 +3,7 @@
 extern zend_module_entry aikido_module_entry;
 #define phpext_aikido_ptr &aikido_module_entry
 
-#define PHP_AIKIDO_VERSION "1.3.0"
+#define PHP_AIKIDO_VERSION "1.3.1"
 
 #if defined(ZTS) && defined(COMPILE_DL_AIKIDO)
 ZEND_TSRMLS_CACHE_EXTERN()

--- a/lib/request-processor/globals/globals.go
+++ b/lib/request-processor/globals/globals.go
@@ -14,5 +14,5 @@ var CloudConfigMutex sync.Mutex
 var MiddlewareInstalled bool
 
 const (
-	Version = "1.3.0"
+	Version = "1.3.1"
 )

--- a/package/rpm/aikido.spec
+++ b/package/rpm/aikido.spec
@@ -1,5 +1,5 @@
 Name:           aikido-php-firewall
-Version:        1.3.0
+Version:        1.3.1
 Release:        1
 Summary:        Aikido PHP Extension
 License:        GPL


### PR DESCRIPTION
- Changed build pipeline to use PHP built from source directly, in order to be able to compile on Ubuntu 20.04
  - As Ubuntu 20.04 is end of life, we cannot use the old packages / mirrors anymore so it's better to just build PHP ourselves (helps also for future features)