### PR TITLE
Update Laravel Forge instructions for Aikido token

### DIFF
--- a/docs/laravel-forge.md
+++ b/docs/laravel-forge.md
@@ -1,6 +1,6 @@
 # Laravel Forge
 
-In Forge, go to your server -> `Settings` -> `Environment` and add the `AIKIDO_TOKEN` in the .env file. Optionally, you can set `AIKIDO_BLOCK` to 1 to enabling blocking mode for attacks.
+In Forge, go to your server -> `Settings` -> `Environment` and add the `AIKIDO_TOKEN` in the .env file.
 
 ![Forge Environment](./forge-environment.png)
 
@@ -8,7 +8,7 @@ You can get your token from the [Aikido Security Dashboard](https://help.aikido.
 
 Go to "Commands" and run the following by replacing the sudo password with the one that Forge displays when the server is created:
 ```
-curl -L -O https://github.com/AikidoSec/firewall-php/releases/download/v1.4.6/aikido-php-firewall.x86_64.deb && echo "YOUR_SUDO_PASSWORD_HERE" | sudo -S dpkg -i -E ./aikido-php-firewall.x86_64.deb && echo "YOUR_SUDO_PASSWORD_HERE" | sudo service php8.4-fpm restart
+curl -L -O https://github.com/AikidoSec/firewall-php/releases/download/v1.4.6/aikido-php-firewall.x86_64.deb && echo "YOUR_SUDO_PASSWORD_HERE" | sudo -S dpkg -i -E ./aikido-php-firewall.x86_64.deb && echo "YOUR_SUDO_PASSWORD_HERE" | sudo -S service php8.4-fpm restart
 ```
 
 ![Forge Commands](./forge-commands.png)


### PR DESCRIPTION
Removed optional instruction for enabling blocking mode in the Aikido token setup.