### PR TITLE
Load Aikido config until a valid token is obtained for non apache-mod-php servers

### DIFF
--- a/lib/php-extension/RequestProcessor.cpp
+++ b/lib/php-extension/RequestProcessor.cpp
@@ -180,10 +180,11 @@ bool RequestProcessor::RequestInit() {
         this->LoadConfigFromEnvironment();
     } else {
         // Server APIs that are not apache-mod-php (like php-fpm, cli-server, ...) 
-        //  can only serve one site per process, so the config should be loaded only once.
-        // After that, subsequent requests cannot change the config so we do not need to reload it.
-        if (this->numberOfRequests == 0) {
-            AIKIDO_LOG_INFO("Loading Aikido config one time for non-apache-mod-php SAPI: %s...\n", AIKIDO_GLOBAL(sapi_name).c_str());
+        //  can only serve one site per process, so the config should be loaded at the first request.
+        // If the token is not set at the first request, we try to reload it until we get a valid token.
+        // The user can update .env file via zero downtime deployments after the PHP server is started.
+        if (AIKIDO_GLOBAL(token) == "") {
+            AIKIDO_LOG_INFO("Loading Aikido config until we get a valid token for SAPI: %s...\n", AIKIDO_GLOBAL(sapi_name).c_str());
             this->LoadConfigFromEnvironment();
         }
     }


### PR DESCRIPTION
- Users can set zero downtime deployments (Forge, Envoyer) that update .env after the server is started
- In order to not require an additional restart, we can try to reload the .env for non apache-mod-php SAPIs (php-fpm) until we actually get a valid AIKIDO_TOKEN