### PR TITLE
Fix false positive shell injection for user input that is a substring of quoted content

### DIFF
--- a/lib/request-processor/vulnerabilities/shell-injection/detectShellInjection_test.go
+++ b/lib/request-processor/vulnerabilities/shell-injection/detectShellInjection_test.go
@@ -114,6 +114,7 @@ func TestDetectShellInjection(t *testing.T) {
 
 	t.Run("allows safe commands within single quotes", func(t *testing.T) {
 		isNotShellInjection(t, "echo 'safe command'", "safe command")
+		isNotShellInjection(t, "ls '/var/a b/c'", "a b")
 	})
 
 	t.Run("detects unsafe use of variables", func(t *testing.T) {

--- a/lib/request-processor/vulnerabilities/shell-injection/isSafelyEncapsulated.go
+++ b/lib/request-processor/vulnerabilities/shell-injection/isSafelyEncapsulated.go
@@ -4,62 +4,83 @@ import (
 	"strings"
 )
 
-var (
-	escapeChars                      = []string{`"`, `'`}
-	dangerousCharsInsideDoubleQuotes = []string{"$", "`", "\\", "!"}
-)
+var dangerousCharsInsideDoubleQuotes = []string{"$", "`", "\\", "!"}
+
+type quoteRegion struct {
+	start     int
+	end       int
+	quoteChar byte
+}
+
+// parseQuoteRegions walks the command and returns all properly closed
+// single-quote and double-quote regions. Inside double quotes, backslash
+// escapes are respected (per POSIX/bash rules); single quotes have no
+// escape mechanism.
+func parseQuoteRegions(command string) []quoteRegion {
+	var regions []quoteRegion
+	i := 0
+	for i < len(command) {
+		ch := command[i]
+		if ch == '\'' || ch == '"' {
+			start := i
+			i++
+			for i < len(command) && command[i] != ch {
+				if ch == '"' && command[i] == '\\' {
+					i++
+				}
+				i++
+			}
+			if i < len(command) {
+				regions = append(regions, quoteRegion{start: start, end: i, quoteChar: ch})
+			}
+			i++
+		} else {
+			i++
+		}
+	}
+	return regions
+}
 
 func isSafelyEncapsulated(command, userInput string) bool {
-	segments := strings.Split(command, userInput)
+	regions := parseQuoteRegions(command)
 
-	for i := 0; i < len(segments)-1; i++ {
-		currentSegment := segments[i]
-		nextSegment := segments[i+1]
-
-		// Get the character before and after the user input
-		charBeforeUserInput := ""
-		if len(currentSegment) > 0 {
-			charBeforeUserInput = currentSegment[len(currentSegment)-1:]
+	idx := 0
+	for {
+		pos := strings.Index(command[idx:], userInput)
+		if pos == -1 {
+			break
 		}
+		absStart := idx + pos
+		absEnd := absStart + len(userInput) - 1
 
-		charAfterUserInput := ""
-		if len(nextSegment) > 0 {
-			charAfterUserInput = nextSegment[:1]
-		}
-
-		// Check if the character before the user input is an escape character
-		isEscapeChar := false
-		for _, char := range escapeChars {
-			if char == charBeforeUserInput {
-				isEscapeChar = true
-				break
-			}
-		}
-
-		if !isEscapeChar {
-			return false
-		}
-
-		// Check if the character before and after the user input are the same
-		if charBeforeUserInput != charAfterUserInput {
-			return false
-		}
-
-		// Check if the user input contains the escape character itself
-		if strings.Contains(userInput, charBeforeUserInput) {
-			return false
-		}
-
-		// Check for dangerous characters inside double quotes
-		// https://www.gnu.org/software/bash/manual/html_node/Single-Quotes.html
-		// https://www.gnu.org/software/bash/manual/html_node/Double-Quotes.html
-		if charBeforeUserInput == `"` {
-			for _, dangerousChar := range dangerousCharsInsideDoubleQuotes {
-				if strings.Contains(userInput, dangerousChar) {
-					return false
+		inSafeQuote := false
+		for _, region := range regions {
+			if absStart > region.start && absEnd < region.end {
+				if region.quoteChar == '\'' {
+					inSafeQuote = true
+					break
+				}
+				if region.quoteChar == '"' {
+					hasDangerous := false
+					for _, dc := range dangerousCharsInsideDoubleQuotes {
+						if strings.Contains(userInput, dc) {
+							hasDangerous = true
+							break
+						}
+					}
+					if !hasDangerous {
+						inSafeQuote = true
+						break
+					}
 				}
 			}
 		}
+
+		if !inSafeQuote {
+			return false
+		}
+
+		idx = absStart + 1
 	}
 
 	return true

--- a/lib/request-processor/vulnerabilities/shell-injection/isSafelyEncapsulated_test.go
+++ b/lib/request-processor/vulnerabilities/shell-injection/isSafelyEncapsulated_test.go
@@ -76,4 +76,92 @@ func TestIsSafelyEncapsulated(t *testing.T) {
 			t.Errorf("isSafelyEncapsulated('echo \"USER\"', '$USER') = %v; want true", got)
 		}
 	})
+
+	t.Run("user input is substring of single-quoted content", func(t *testing.T) {
+		if got := isSafelyEncapsulated("ls '/var/a b/c'", "a b"); got != true {
+			t.Errorf("isSafelyEncapsulated(\"ls '/var/a b/c'\", \"a b\") = %v; want true", got)
+		}
+		if got := isSafelyEncapsulated("grep 'hello world' file.txt", "hello world"); got != true {
+			t.Errorf("isSafelyEncapsulated(\"grep 'hello world' file.txt\", \"hello world\") = %v; want true", got)
+		}
+		if got := isSafelyEncapsulated("echo 'prefix foo suffix'", "foo"); got != true {
+			t.Errorf("isSafelyEncapsulated(\"echo 'prefix foo suffix'\", \"foo\") = %v; want true", got)
+		}
+	})
+
+	t.Run("user input is substring of double-quoted content without dangerous chars", func(t *testing.T) {
+		if got := isSafelyEncapsulated(`ls "/var/a b/c"`, "a b"); got != true {
+			t.Errorf(`isSafelyEncapsulated("ls \"/var/a b/c\"", "a b") = %v; want true`, got)
+		}
+		if got := isSafelyEncapsulated(`grep "hello world" file.txt`, "hello world"); got != true {
+			t.Errorf(`isSafelyEncapsulated("grep \"hello world\" file.txt", "hello world") = %v; want true`, got)
+		}
+	})
+
+	t.Run("user input is substring of double-quoted content with dangerous chars", func(t *testing.T) {
+		if got := isSafelyEncapsulated(`echo "/tmp/$USER/dir"`, "$USER"); got != false {
+			t.Errorf(`isSafelyEncapsulated("echo \"/tmp/$USER/dir\"", "$USER") = %v; want false`, got)
+		}
+		if got := isSafelyEncapsulated("echo \"/tmp/`whoami`/dir\"", "`whoami`"); got != false {
+			t.Errorf("isSafelyEncapsulated with backticks substring in double quotes = %v; want false", got)
+		}
+	})
+
+	t.Run("user input spans across quote boundary", func(t *testing.T) {
+		if got := isSafelyEncapsulated("echo 'hello' world", "lo' wo"); got != false {
+			t.Errorf("isSafelyEncapsulated spanning quote boundary = %v; want false", got)
+		}
+		if got := isSafelyEncapsulated(`echo "hello" world`, `lo" wo`); got != false {
+			t.Errorf("isSafelyEncapsulated spanning double-quote boundary = %v; want false", got)
+		}
+	})
+
+	t.Run("user input is the entire quoted content", func(t *testing.T) {
+		if got := isSafelyEncapsulated("echo 'hello'", "hello"); got != true {
+			t.Errorf("isSafelyEncapsulated entire single-quoted content = %v; want true", got)
+		}
+		if got := isSafelyEncapsulated(`echo "hello"`, "hello"); got != true {
+			t.Errorf("isSafelyEncapsulated entire double-quoted content = %v; want true", got)
+		}
+	})
+
+	t.Run("unterminated quotes", func(t *testing.T) {
+		if got := isSafelyEncapsulated("echo 'hello", "hello"); got != false {
+			t.Errorf("isSafelyEncapsulated unterminated single quote = %v; want false", got)
+		}
+		if got := isSafelyEncapsulated(`echo "hello`, "hello"); got != false {
+			t.Errorf("isSafelyEncapsulated unterminated double quote = %v; want false", got)
+		}
+	})
+
+	t.Run("single quotes inside double quotes are literal", func(t *testing.T) {
+		if got := isSafelyEncapsulated(`echo "it's fine"`, "it's fine"); got != true {
+			t.Errorf(`isSafelyEncapsulated("echo \"it's fine\"", "it's fine") = %v; want true`, got)
+		}
+	})
+
+	t.Run("double quotes inside single quotes are literal", func(t *testing.T) {
+		if got := isSafelyEncapsulated(`echo 'say "hi"'`, `say "hi"`); got != true {
+			t.Errorf(`isSafelyEncapsulated single-quoted with inner double quotes = %v; want true`, got)
+		}
+	})
+
+	t.Run("escaped double quote inside double quotes", func(t *testing.T) {
+		if got := isSafelyEncapsulated(`echo "hello \"world\""`, "hello"); got != true {
+			t.Errorf("isSafelyEncapsulated with escaped quotes = %v; want true", got)
+		}
+	})
+
+	t.Run("user input appears both inside and outside quotes", func(t *testing.T) {
+		if got := isSafelyEncapsulated("echo 'foo' foo", "foo"); got != false {
+			t.Errorf("isSafelyEncapsulated with one safe and one unsafe occurrence = %v; want false", got)
+		}
+	})
+
+	t.Run("multiple safe occurrences in different quote types", func(t *testing.T) {
+		if got := isSafelyEncapsulated(`echo 'foo' "foo"`, "foo"); got != true {
+			t.Errorf("isSafelyEncapsulated with safe occurrences in both quote types = %v; want true", got)
+		}
+	})
+
 }


### PR DESCRIPTION
<!-- AIKIDO_SECURITY_PR_SUMMARY_START -->
## Summary by Aikido
|  Security Issues: 0 | 🔍 Quality Issues: 2 |  Resolved Issues: 0 |
| :--- | :--- | :--- |


**⚡ Enhancements**
* Added parseQuoteRegions to identify properly closed quoted regions

**🐛 Bugfixes**
* Fixed false positive detection when user input was substring of quoted content

**🔧 Refactors**
* Removed simplistic escape-character checks and centralized dangerous-chars handling


<sup>[More info](https://app.aikido.dev/featurebranch/scan/97355705?groupId=6)</sup>
<!-- AIKIDO_SECURITY_PR_SUMMARY_END -->