### PR TITLE
Fix: prevent Go runtime init in FPM master during opcache.preload

### DIFF
--- a/lib/php-extension/Handle.cpp
+++ b/lib/php-extension/Handle.cpp
@@ -84,7 +84,7 @@ ZEND_NAMED_FUNCTION(aikido_generic_handler) {
             return;
         }
 
-        if (IsAikidoDisabledOrBypassed()) {
+        if (IsAikidoDisabledOrBypassed() || AIKIDO_GLOBAL(phpLifecycle).IsFpmMasterPreloadCycle()) {
             if (original_handler) {
                 original_handler(INTERNAL_FUNCTION_PARAM_PASSTHRU);
             }

--- a/lib/php-extension/Handle.cpp
+++ b/lib/php-extension/Handle.cpp
@@ -84,7 +84,7 @@ ZEND_NAMED_FUNCTION(aikido_generic_handler) {
             return;
         }
 
-        if (IsAikidoDisabledOrBypassed() || AIKIDO_GLOBAL(phpLifecycle).IsFpmMasterPreloadCycle()) {
+        if (IsAikidoDisabledOrBypassed() || AIKIDO_GLOBAL(phpLifecycle).IsRequestHandledInMainPid()) {
             if (original_handler) {
                 original_handler(INTERNAL_FUNCTION_PARAM_PASSTHRU);
             }

--- a/lib/php-extension/HandleFileCompilation.cpp
+++ b/lib/php-extension/HandleFileCompilation.cpp
@@ -1,7 +1,7 @@
 #include "Includes.h"
 
 zend_op_array* handle_file_compilation(zend_file_handle* file_handle, int type) {
-    if(AIKIDO_GLOBAL(disable) == true || AIKIDO_GLOBAL(phpLifecycle).IsFpmMasterPreloadCycle()) {
+    if(AIKIDO_GLOBAL(disable) == true || AIKIDO_GLOBAL(phpLifecycle).IsRequestHandledInMainPid()) {
         return original_file_compilation_handler(file_handle, type);
     }
 

--- a/lib/php-extension/HandleFileCompilation.cpp
+++ b/lib/php-extension/HandleFileCompilation.cpp
@@ -1,7 +1,7 @@
 #include "Includes.h"
 
 zend_op_array* handle_file_compilation(zend_file_handle* file_handle, int type) {
-    if(AIKIDO_GLOBAL(disable) == true) {
+    if(AIKIDO_GLOBAL(disable) == true || AIKIDO_GLOBAL(phpLifecycle).IsFpmMasterPreloadCycle()) {
         return original_file_compilation_handler(file_handle, type);
     }
 

--- a/lib/php-extension/HookAst.cpp
+++ b/lib/php-extension/HookAst.cpp
@@ -116,7 +116,7 @@ void insert_call_to_ast(zend_ast *ast) {
 void aikido_ast_process(zend_ast *ast) {
     auto& original_ast_process = AIKIDO_GLOBAL(originalAstProcess);
 
-    if(AIKIDO_GLOBAL(disable) == true) {
+    if(AIKIDO_GLOBAL(disable) == true || AIKIDO_GLOBAL(phpLifecycle).IsFpmMasterPreloadCycle()) {
         if(original_ast_process){
             original_ast_process(ast);
         }

--- a/lib/php-extension/HookAst.cpp
+++ b/lib/php-extension/HookAst.cpp
@@ -116,7 +116,7 @@ void insert_call_to_ast(zend_ast *ast) {
 void aikido_ast_process(zend_ast *ast) {
     auto& original_ast_process = AIKIDO_GLOBAL(originalAstProcess);
 
-    if(AIKIDO_GLOBAL(disable) == true || AIKIDO_GLOBAL(phpLifecycle).IsFpmMasterPreloadCycle()) {
+    if(AIKIDO_GLOBAL(disable) == true || AIKIDO_GLOBAL(phpLifecycle).IsRequestHandledInMainPid()) {
         if(original_ast_process){
             original_ast_process(ast);
         }

--- a/lib/php-extension/PhpLifecycle.cpp
+++ b/lib/php-extension/PhpLifecycle.cpp
@@ -21,8 +21,8 @@ void PhpLifecycle::RequestInit() {
     // cycle: running it there would dlopen aikido-request-processor.so in
     // the master, and every forked worker would inherit a Go runtime whose
     // scheduler threads do not exist in its address space.
-    #ifdef NTS
-    if (this->mainPID == getpid() && AIKIDO_GLOBAL(sapi_name) != "cli") {
+   #ifdef NTS
+    if (this->mainPID == getpid() && AIKIDO_GLOBAL(sapi_name) == "fpm-fcgi"){
         AIKIDO_LOG_INFO("Skipping RequestInit in php-fpm master (pid %d == mainPID; "
                         "likely opcache.preload virtual RINIT). Workers will initialize "
                         "the request processor after fork.\n", (int)getpid());

--- a/lib/php-extension/PhpLifecycle.cpp
+++ b/lib/php-extension/PhpLifecycle.cpp
@@ -16,19 +16,31 @@ void PhpLifecycle::ModuleInit() {
     }
 }
 
-void PhpLifecycle::RequestInit() {
-    // Skip RequestInit in the php-fpm master's opcache.preload virtual RINIT
-    // cycle: running it there would dlopen aikido-request-processor.so in
-    // the master, and every forked worker would inherit a Go runtime whose
-    // scheduler threads do not exist in its address space.
+bool PhpLifecycle::IsFpmMasterPreloadCycle() const {
+    // Skip any Aikido work that would dlopen aikido-request-processor.so in
+    // the php-fpm / apache master's opcache.preload virtual RINIT cycle:
+    // loading the Go runtime there would make every forked worker inherit
+    // a runtime whose scheduler threads do not exist in its address space.
     #ifndef ZTS
-    if (this->mainPID == getpid() && (AIKIDO_GLOBAL(sapi_name) == "fpm-fcgi" || AIKIDO_GLOBAL(sapi_name) == "apache2handler")){
-        AIKIDO_LOG_INFO("Skipping RequestInit in php-fpm master (pid %d == mainPID; "
-                        "likely opcache.preload virtual RINIT). Workers will initialize "
-                        "the request processor after fork.\n", (int)getpid());
-        return;
-    }   
+        if (this->mainPID != 0 && this->mainPID == getpid()) {
+            const std::string& sapi = AIKIDO_GLOBAL(sapi_name);
+            if (sapi == "fpm-fcgi" || sapi == "apache2handler") {
+                return true;
+            }
+        }
     #endif
+    return false;
+}
+
+
+void PhpLifecycle::RequestInit() {
+    if (IsFpmMasterPreloadCycle()) {
+        AIKIDO_LOG_INFO("Skipping RequestInit in %s master (pid %d == mainPID; "
+                        "likely opcache.preload virtual RINIT). Workers will "
+                        "initialize the request processor after fork.\n",
+                        AIKIDO_GLOBAL(sapi_name).c_str(), (int)getpid());
+        return;
+    }
 
     AIKIDO_GLOBAL(action).Reset();
     AIKIDO_GLOBAL(requestCache).Reset();
@@ -42,6 +54,9 @@ void PhpLifecycle::RequestInit() {
 }
 
 void PhpLifecycle::RequestShutdown() {
+    if (IsFpmMasterPreloadCycle()) {
+        return;
+    }
     AIKIDO_GLOBAL(requestProcessorInstance).RequestShutdown();
 }
 

--- a/lib/php-extension/PhpLifecycle.cpp
+++ b/lib/php-extension/PhpLifecycle.cpp
@@ -21,13 +21,15 @@ void PhpLifecycle::RequestInit() {
     // cycle: running it there would dlopen aikido-request-processor.so in
     // the master, and every forked worker would inherit a Go runtime whose
     // scheduler threads do not exist in its address space.
+    #ifndef ZTS
     if (this->mainPID == getpid() && AIKIDO_GLOBAL(sapi_name) == "fpm-fcgi"){
         AIKIDO_LOG_INFO("Skipping RequestInit in php-fpm master (pid %d == mainPID; "
                         "likely opcache.preload virtual RINIT). Workers will initialize "
                         "the request processor after fork.\n", (int)getpid());
         return;
-    }
-
+    }   
+    #endif
+    
     AIKIDO_GLOBAL(action).Reset();
     AIKIDO_GLOBAL(requestCache).Reset();
     

--- a/lib/php-extension/PhpLifecycle.cpp
+++ b/lib/php-extension/PhpLifecycle.cpp
@@ -17,6 +17,22 @@ void PhpLifecycle::ModuleInit() {
 }
 
 void PhpLifecycle::RequestInit() {
+    // Skip RequestInit in the php-fpm master's opcache.preload virtual RINIT
+    // cycle: running it there would dlopen aikido-request-processor.so in
+    // the master, and every forked worker would inherit a Go runtime whose
+    // scheduler threads do not exist in its address space (fork clones only
+    // the calling thread), causing gRPC calls from workers to hang ~60s.
+    // Gated on fpm-fcgi because cli-server / frankenphp are single-process
+    // and would match `mainPID == getpid()` for every real request too.
+    #ifndef ZTS
+    if (this->mainPID == getpid() && AIKIDO_GLOBAL(sapi_name) == "fpm-fcgi") {
+        AIKIDO_LOG_INFO("Skipping RequestInit in php-fpm master (pid %d == mainPID; "
+                        "likely opcache.preload virtual RINIT). Workers will initialize "
+                        "the request processor after fork.\n", (int)getpid());
+        return;
+    }
+    #endif
+
     AIKIDO_GLOBAL(action).Reset();
     AIKIDO_GLOBAL(requestCache).Reset();
     

--- a/lib/php-extension/PhpLifecycle.cpp
+++ b/lib/php-extension/PhpLifecycle.cpp
@@ -21,13 +21,14 @@ void PhpLifecycle::RequestInit() {
     // cycle: running it there would dlopen aikido-request-processor.so in
     // the master, and every forked worker would inherit a Go runtime whose
     // scheduler threads do not exist in its address space.
+    #ifdef NTS
     if (this->mainPID == getpid() && AIKIDO_GLOBAL(sapi_name) != "cli") {
         AIKIDO_LOG_INFO("Skipping RequestInit in php-fpm master (pid %d == mainPID; "
                         "likely opcache.preload virtual RINIT). Workers will initialize "
                         "the request processor after fork.\n", (int)getpid());
         return;
     }
-
+    #endif
 
     AIKIDO_GLOBAL(action).Reset();
     AIKIDO_GLOBAL(requestCache).Reset();

--- a/lib/php-extension/PhpLifecycle.cpp
+++ b/lib/php-extension/PhpLifecycle.cpp
@@ -20,8 +20,7 @@ void PhpLifecycle::RequestInit() {
     // Skip RequestInit in the php-fpm master's opcache.preload virtual RINIT
     // cycle: running it there would dlopen aikido-request-processor.so in
     // the master, and every forked worker would inherit a Go runtime whose
-    // scheduler threads do not exist in its address space (fork clones only
-    // the calling thread), causing gRPC calls from workers to hang ~60s.
+    // scheduler threads do not exist in its address space.
     #ifndef ZTS
         if (this->mainPID == getpid() && AIKIDO_GLOBAL(sapi_name) != "cli") {
             AIKIDO_LOG_INFO("Skipping RequestInit in php-fpm master (pid %d == mainPID; "

--- a/lib/php-extension/PhpLifecycle.cpp
+++ b/lib/php-extension/PhpLifecycle.cpp
@@ -23,8 +23,7 @@ bool PhpLifecycle::IsFpmMasterPreloadCycle() const {
     // a runtime whose scheduler threads do not exist in its address space.
     #ifndef ZTS
         if (this->mainPID != 0 && this->mainPID == getpid()) {
-            const std::string& sapi = AIKIDO_GLOBAL(sapi_name);
-            if (sapi == "fpm-fcgi" || sapi == "apache2handler") {
+            if (AIKIDO_GLOBAL(sapi_name) == "fpm-fcgi" || AIKIDO_GLOBAL(sapi_name) == "apache2handler") {
                 return true;
             }
         }

--- a/lib/php-extension/PhpLifecycle.cpp
+++ b/lib/php-extension/PhpLifecycle.cpp
@@ -22,14 +22,14 @@ void PhpLifecycle::RequestInit() {
     // the master, and every forked worker would inherit a Go runtime whose
     // scheduler threads do not exist in its address space.
     #ifndef ZTS
-    if (this->mainPID == getpid() && AIKIDO_GLOBAL(sapi_name) == "fpm-fcgi"){
+    if (this->mainPID == getpid() && (AIKIDO_GLOBAL(sapi_name) == "fpm-fcgi" || AIKIDO_GLOBAL(sapi_name) == "apache2handler")){
         AIKIDO_LOG_INFO("Skipping RequestInit in php-fpm master (pid %d == mainPID; "
                         "likely opcache.preload virtual RINIT). Workers will initialize "
                         "the request processor after fork.\n", (int)getpid());
         return;
     }   
     #endif
-    
+
     AIKIDO_GLOBAL(action).Reset();
     AIKIDO_GLOBAL(requestCache).Reset();
     

--- a/lib/php-extension/PhpLifecycle.cpp
+++ b/lib/php-extension/PhpLifecycle.cpp
@@ -16,7 +16,7 @@ void PhpLifecycle::ModuleInit() {
     }
 }
 
-bool PhpLifecycle::IsFpmMasterPreloadCycle() const {
+bool PhpLifecycle::IsRequestHandledInMainPid() const {
     // Skip any Aikido work that would dlopen aikido-request-processor.so in
     // the php-fpm / apache master's opcache.preload virtual RINIT cycle:
     // loading the Go runtime there would make every forked worker inherit
@@ -33,7 +33,7 @@ bool PhpLifecycle::IsFpmMasterPreloadCycle() const {
 
 
 void PhpLifecycle::RequestInit() {
-    if (IsFpmMasterPreloadCycle()) {
+    if (IsRequestHandledInMainPid()) {
         AIKIDO_LOG_INFO("Skipping RequestInit in %s master (pid %d == mainPID; "
                         "likely opcache.preload virtual RINIT). Workers will "
                         "initialize the request processor after fork.\n",
@@ -53,7 +53,7 @@ void PhpLifecycle::RequestInit() {
 }
 
 void PhpLifecycle::RequestShutdown() {
-    if (IsFpmMasterPreloadCycle()) {
+    if (IsRequestHandledInMainPid()) {
         return;
     }
     AIKIDO_GLOBAL(requestProcessorInstance).RequestShutdown();

--- a/lib/php-extension/PhpLifecycle.cpp
+++ b/lib/php-extension/PhpLifecycle.cpp
@@ -21,14 +21,12 @@ void PhpLifecycle::RequestInit() {
     // cycle: running it there would dlopen aikido-request-processor.so in
     // the master, and every forked worker would inherit a Go runtime whose
     // scheduler threads do not exist in its address space.
-   #ifdef NTS
     if (this->mainPID == getpid() && AIKIDO_GLOBAL(sapi_name) == "fpm-fcgi"){
         AIKIDO_LOG_INFO("Skipping RequestInit in php-fpm master (pid %d == mainPID; "
                         "likely opcache.preload virtual RINIT). Workers will initialize "
                         "the request processor after fork.\n", (int)getpid());
         return;
     }
-    #endif
 
     AIKIDO_GLOBAL(action).Reset();
     AIKIDO_GLOBAL(requestCache).Reset();

--- a/lib/php-extension/PhpLifecycle.cpp
+++ b/lib/php-extension/PhpLifecycle.cpp
@@ -22,15 +22,13 @@ void PhpLifecycle::RequestInit() {
     // the master, and every forked worker would inherit a Go runtime whose
     // scheduler threads do not exist in its address space (fork clones only
     // the calling thread), causing gRPC calls from workers to hang ~60s.
-    // Gated on fpm-fcgi because cli-server / frankenphp are single-process
-    // and would match `mainPID == getpid()` for every real request too.
     #ifndef ZTS
-    if (this->mainPID == getpid() && AIKIDO_GLOBAL(sapi_name) == "fpm-fcgi") {
-        AIKIDO_LOG_INFO("Skipping RequestInit in php-fpm master (pid %d == mainPID; "
-                        "likely opcache.preload virtual RINIT). Workers will initialize "
-                        "the request processor after fork.\n", (int)getpid());
-        return;
-    }
+        if (this->mainPID == getpid() && AIKIDO_GLOBAL(sapi_name) != "cli") {
+            AIKIDO_LOG_INFO("Skipping RequestInit in php-fpm master (pid %d == mainPID; "
+                            "likely opcache.preload virtual RINIT). Workers will initialize "
+                            "the request processor after fork.\n", (int)getpid());
+            return;
+        }
     #endif
 
     AIKIDO_GLOBAL(action).Reset();

--- a/lib/php-extension/PhpLifecycle.cpp
+++ b/lib/php-extension/PhpLifecycle.cpp
@@ -21,14 +21,13 @@ void PhpLifecycle::RequestInit() {
     // cycle: running it there would dlopen aikido-request-processor.so in
     // the master, and every forked worker would inherit a Go runtime whose
     // scheduler threads do not exist in its address space.
-    #ifndef ZTS
-        if (this->mainPID == getpid() && AIKIDO_GLOBAL(sapi_name) != "cli") {
-            AIKIDO_LOG_INFO("Skipping RequestInit in php-fpm master (pid %d == mainPID; "
-                            "likely opcache.preload virtual RINIT). Workers will initialize "
-                            "the request processor after fork.\n", (int)getpid());
-            return;
-        }
-    #endif
+    if (this->mainPID == getpid() && AIKIDO_GLOBAL(sapi_name) != "cli") {
+        AIKIDO_LOG_INFO("Skipping RequestInit in php-fpm master (pid %d == mainPID; "
+                        "likely opcache.preload virtual RINIT). Workers will initialize "
+                        "the request processor after fork.\n", (int)getpid());
+        return;
+    }
+
 
     AIKIDO_GLOBAL(action).Reset();
     AIKIDO_GLOBAL(requestCache).Reset();

--- a/lib/php-extension/include/PhpLifecycle.h
+++ b/lib/php-extension/include/PhpLifecycle.h
@@ -20,5 +20,5 @@ class PhpLifecycle {
 
     void UnhookAll();
 
-    bool IsFpmMasterPreloadCycle() const;
+    bool IsFpmMasterPreloadCycle();
 };

--- a/lib/php-extension/include/PhpLifecycle.h
+++ b/lib/php-extension/include/PhpLifecycle.h
@@ -20,5 +20,5 @@ class PhpLifecycle {
 
     void UnhookAll();
 
-    bool IsFpmMasterPreloadCycle();
+    bool IsFpmMasterPreloadCycle() const;
 };

--- a/lib/php-extension/include/PhpLifecycle.h
+++ b/lib/php-extension/include/PhpLifecycle.h
@@ -20,5 +20,5 @@ class PhpLifecycle {
 
     void UnhookAll();
 
-    bool IsFpmMasterPreloadCycle() const;
+    bool IsRequestHandledInMainPid() const;
 };

--- a/lib/php-extension/include/PhpLifecycle.h
+++ b/lib/php-extension/include/PhpLifecycle.h
@@ -19,4 +19,6 @@ class PhpLifecycle {
     void HookAll();
 
     void UnhookAll();
+
+    bool IsFpmMasterPreloadCycle() const;
 };


### PR DESCRIPTION
When `opcache.preload` is configured under php-fpm, the master runs a virtual RINIT for the preload script before forking workers. That used to dlopen Aikido's Go request-processor in the master, spawning Go's scheduler/GC/netpoll kernel threads there. `fork()` only clones the calling thread, so workers inherited a Go runtime whose internal tables pointed at threads that didn't exist in their address space.

<!-- AIKIDO_SECURITY_PR_SUMMARY_START -->
## Summary by Aikido
|  Security Issues: 0 |  Quality Issues: 0 |  Resolved Issues: 0 |
| :--- | :--- | :--- |


**🐛 Bugfixes**
* Added IsRequestHandledInMainPid method to detect opcache.preload master RINIT.
* Short-circuited AST, handler, and compilation paths when master handled requests.


<sup>[More info](https://app.aikido.dev/featurebranch/scan/106949412?groupId=6)</sup>
<!-- AIKIDO_SECURITY_PR_SUMMARY_END -->