### PR TITLE
Fix stats leak when AIKIDO_DISABLE is set

### DIFF
--- a/lib/php-extension/RequestProcessor.cpp
+++ b/lib/php-extension/RequestProcessor.cpp
@@ -258,6 +258,9 @@ bool RequestProcessorInstance::RequestInit() {
     AIKIDO_LOG_DEBUG("RINIT started!\n");
 
     if (AIKIDO_GLOBAL(disable) == true) {
+        if (!AIKIDO_GLOBAL(stats).empty()) {
+            AIKIDO_GLOBAL(stats).clear();
+        }
         AIKIDO_LOG_INFO("Request Processor initialization skipped because AIKIDO_DISABLE is set to 1!\n");
         return true;
     }

--- a/lib/request-processor/grpc/client.go
+++ b/lib/request-processor/grpc/client.go
@@ -269,7 +269,7 @@ func OnMonitoredSinkStats(server *ServerData, token string, sink, kind string, a
 		Timings:               timings,
 	})
 	if err != nil {
-		log.Warnf(nil, "Could not send monitored sink stats event")
+		log.Debugf(nil, "Could not send monitored sink stats event: %v", err)
 		return
 	}
 	log.Debugf(nil, "Monitored sink stats for sink \"%s\" sent via socket", sink)


### PR DESCRIPTION
- Clear stats on request processor initialization when aikido_disabled is set
- Downgrade logging message to debug to avoid spam

<!-- AIKIDO_SECURITY_PR_SUMMARY_START -->
## Summary by Aikido
|  Security Issues: 0 |  Quality Issues: 0 |  Resolved Issues: 0 |
| :--- | :--- | :--- |


**⚡ Enhancements**
* Lowered request processor initialization log level from info to debug

**🐛 Bugfixes**
* Cleared accumulated request processor stats when AIKIDO_DISABLE was set


<sup>[More info](https://app.aikido.dev/featurebranch/scan/109925020?groupId=6)</sup>
<!-- AIKIDO_SECURITY_PR_SUMMARY_END -->