### PR TITLE
Fix bypass via nested query parameters

### DIFF
--- a/lib/php-extension/Utils.cpp
+++ b/lib/php-extension/Utils.cpp
@@ -72,31 +72,53 @@ std::string NormalizeAndDumpJson(const json& jsonObj) {
     return jsonObj.dump(-1, ' ', false, json::error_handler_t::ignore);
 }
 
+static json ZvalToJsonValue(zval* val, int depth) {
+    const int MAX_DEPTH = 20;
+    if (!val || depth > MAX_DEPTH) {
+        return nullptr;
+    }
+
+    if (Z_TYPE_P(val) == IS_REFERENCE) {
+        val = Z_REFVAL_P(val);
+    }
+
+    if (Z_TYPE_P(val) == IS_STRING) {
+        return std::string(Z_STRVAL_P(val), Z_STRLEN_P(val));
+    }
+
+    if (Z_TYPE_P(val) == IS_ARRAY) {
+        json result = json::object();
+        zend_string* str_key;
+        zend_ulong num_key;
+        zval* v;
+        ZEND_HASH_FOREACH_KEY_VAL(Z_ARRVAL_P(val), num_key, str_key, v) {
+            if (str_key) {
+                result[std::string(ZSTR_VAL(str_key), ZSTR_LEN(str_key))] = ZvalToJsonValue(v, depth + 1);
+            } else {
+                result[std::to_string(num_key)] = ZvalToJsonValue(v, depth + 1);
+            }
+        }
+        ZEND_HASH_FOREACH_END();
+        return result;
+    }
+
+    return nullptr;
+}
+
 std::string ArrayToJson(zval* array) {
-    if (!array) {
+    if (!array || Z_TYPE_P(array) != IS_ARRAY) {
         return "";
     }
 
-    json query_json;
-    zend_string *key;
-    zval *val;
-    ZEND_HASH_FOREACH_STR_KEY_VAL(Z_ARRVAL_P(array), key, val) {
-        if(key && val) {
-            std::string key_str(ZSTR_VAL(key));
-            if (Z_TYPE_P(val) == IS_STRING) {
-                query_json[key_str] = Z_STRVAL_P(val);
-            }
-            else if (Z_TYPE_P(val) == IS_ARRAY){
-                json val_array = json::array();
-                zval *v;
-                ZEND_HASH_FOREACH_VAL(Z_ARRVAL_P(val), v) {
-                    if (Z_TYPE_P(v) == IS_STRING) {
-                        val_array.push_back(Z_STRVAL_P(v));
-                    }
-                }
-                ZEND_HASH_FOREACH_END();
-                query_json[key_str] = val_array;
-            }
+    json query_json = json::object();
+    zend_string* key;
+    zend_ulong num_key;
+    zval* val;
+    ZEND_HASH_FOREACH_KEY_VAL(Z_ARRVAL_P(array), num_key, key, val) {
+        if (key) {
+            query_json[std::string(ZSTR_VAL(key), ZSTR_LEN(key))] = ZvalToJsonValue(val, 1);
+        } else {
+            query_json[std::to_string(num_key)] = ZvalToJsonValue(val, 1);
         }
     }
     ZEND_HASH_FOREACH_END();

--- a/tests/cli/sql_injection/sql_injection_nested_get.phpt
+++ b/tests/cli/sql_injection/sql_injection_nested_get.phpt
@@ -1,0 +1,37 @@
+--TEST--
+Test SQL injection detection in nested GET parameters (filters[id][value])
+
+--ENV--
+AIKIDO_LOG_LEVEL=DEBUG
+AIKIDO_BLOCK=1
+
+--GET--
+filters[id][value]=1%20OR%201%3D1--
+
+--FILE--
+<?php
+
+try {
+    $pdo = new PDO('sqlite::memory:');
+    $pdo->setAttribute(PDO::ATTR_ERRMODE, PDO::ERRMODE_EXCEPTION);
+
+    $pdo->exec("CREATE TABLE IF NOT EXISTS users (
+        id INTEGER PRIMARY KEY,
+        name TEXT NOT NULL
+    )");
+
+    $pdo->exec("INSERT INTO users VALUES (1, 'admin')");
+    $pdo->exec("INSERT INTO users VALUES (2, 'user')");
+
+    $id = $_GET['filters']['id']['value'];
+    $result = $pdo->query("SELECT * FROM users WHERE id=" . $id);
+
+    echo "Query executed!";
+
+} catch (PDOException $e) {
+    echo "Error: " . $e->getMessage();
+}
+?>
+
+--EXPECTREGEX--
+.*Fatal error: Uncaught Exception: Aikido firewall has blocked an SQL injection.*

--- a/tests/cli/sql_injection/sql_injection_nested_post.phpt
+++ b/tests/cli/sql_injection/sql_injection_nested_post.phpt
@@ -1,0 +1,37 @@
+--TEST--
+Test SQL injection detection in nested POST parameters (filters[id][value])
+
+--ENV--
+AIKIDO_LOG_LEVEL=DEBUG
+AIKIDO_BLOCK=1
+
+--POST--
+filters[id][value]=1%20OR%201%3D1--
+
+--FILE--
+<?php
+
+try {
+    $pdo = new PDO('sqlite::memory:');
+    $pdo->setAttribute(PDO::ATTR_ERRMODE, PDO::ERRMODE_EXCEPTION);
+
+    $pdo->exec("CREATE TABLE IF NOT EXISTS users (
+        id INTEGER PRIMARY KEY,
+        name TEXT NOT NULL
+    )");
+
+    $pdo->exec("INSERT INTO users VALUES (1, 'admin')");
+    $pdo->exec("INSERT INTO users VALUES (2, 'user')");
+
+    $id = $_POST['filters']['id']['value'];
+    $result = $pdo->query("SELECT * FROM users WHERE id=" . $id);
+
+    echo "Query executed!";
+
+} catch (PDOException $e) {
+    echo "Error: " . $e->getMessage();
+}
+?>
+
+--EXPECTREGEX--
+.*Fatal error: Uncaught Exception: Aikido firewall has blocked an SQL injection.*


### PR DESCRIPTION
Make `ArrayToJson` recursive so all string leaf values are included regardless of nesting depth. Add tests for nested `GET` and `POST` parameter injection.

<!-- AIKIDO_SECURITY_PR_SUMMARY_START -->
## Summary by Aikido
|  Security Issues: 0 | 🔍 Quality Issues: 2 |  Resolved Issues: 0 |
| :--- | :--- | :--- |


**⚡ Enhancements**
* Added ZvalToJsonValue helper with depth limit and type checks

**🐛 Bugfixes**
* Fixed nested query parameter bypass by making ArrayToJson recursive


<sup>[More info](https://app.aikido.dev/featurebranch/scan/110346623?groupId=6)</sup>
<!-- AIKIDO_SECURITY_PR_SUMMARY_END -->