### PR TITLE
Make path traversal containment check case-insensitive

### DIFF
--- a/lib/request-processor/vulnerabilities/path-traversal/detectPathTraversal.go
+++ b/lib/request-processor/vulnerabilities/path-traversal/detectPathTraversal.go
@@ -21,7 +21,7 @@ func detectPathTraversal(filePath string, userInput string, checkPathStart bool)
 		return false
 	}
 
-	if !strings.Contains(filePath, userInput) {
+	if !strings.Contains(strings.ToLower(filePath), strings.ToLower(userInput)) {
 		// We ignore cases where the user input is not part of the file path.
 		return false
 	}

--- a/lib/request-processor/vulnerabilities/path-traversal/detectPathTraversal_test.go
+++ b/lib/request-processor/vulnerabilities/path-traversal/detectPathTraversal_test.go
@@ -237,4 +237,21 @@ func TestDetectPathTraversal(t *testing.T) {
 			}
 		}
 	})
+
+	t.Run("case-insensitive path containment detects traversal on case-insensitive filesystems", func(t *testing.T) {
+		testCases := []struct {
+			inputPath string
+			userPath  string
+			expected  bool
+		}{
+			{"/etc/passwd", "/ETC/passwd", true},
+			{"/etc/passwd", "/ETC/PASSWD", true},
+			{"/home/user/file.txt", "/HOME/USER/file.txt", true},
+		}
+		for _, tc := range testCases {
+			if detectPathTraversal(tc.inputPath, tc.userPath, true) != tc.expected {
+				t.Errorf("expected %v for input %q and user path %q", tc.expected, tc.inputPath, tc.userPath)
+			}
+		}
+	})
 }


### PR DESCRIPTION
Makes the user-input containment check in path traversal detection case-insensitive, matching the fix applied to the Node.js firewall in AikidoSec/firewall-node#1047.

**Problem**: On case-insensitive filesystems (macOS APFS, Windows NTFS), an attacker can submit a path like `/ETC/PASSWD` which resolves to `/etc/passwd`. The detection check `strings.Contains(filePath, userInput)` was case-sensitive, so `/ETC/PASSWD` would not be found in `/etc/passwd` and traversal would go undetected.

**Fix**: Changed to `strings.Contains(strings.ToLower(filePath), strings.ToLower(userInput))`.

See: https://github.com/AikidoSec/firewall-node/pull/1047

<!-- AIKIDO_SECURITY_PR_SUMMARY_START -->
## Summary by Aikido
|  Security Issues: 0 |  Quality Issues: 0 |  Resolved Issues: 0 |
| :--- | :--- | :--- |


**🐛 Bugfixes**
* Made path traversal containment check case-insensitive to prevent bypass


<sup>[More info](https://app.aikido.dev/featurebranch/scan/124651805?groupId=6)</sup>
<!-- AIKIDO_SECURITY_PR_SUMMARY_END -->