### PR TITLE
Trim trailing dot from trusted IMDS hostnames

### DIFF
--- a/lib/request-processor/helpers/normalizeHostname.go
+++ b/lib/request-processor/helpers/normalizeHostname.go
@@ -24,12 +24,15 @@ func NormalizeHostname(hostname string) string {
 	// Convert to lowercase first - idna.ToUnicode requires lowercase "xn--" prefix
 	lowercased := strings.ToLower(decoded)
 
+	// Strip trailing dot — DNS resolvers may return FQDNs like "metadata.google.internal."
+	noDot := strings.TrimSuffix(lowercased, ".")
+
 	// Convert Punycode (xn--...) to Unicode form for consistent comparison
 	// e.g., "xn--mnchen-3ya.de" -> "münchen.de"
-	unicodeHostname, err := idna.ToUnicode(lowercased)
+	unicodeHostname, err := idna.ToUnicode(noDot)
 	if err != nil {
 		// If conversion fails, use the lowercased hostname as-is
-		unicodeHostname = lowercased
+		unicodeHostname = noDot
 	}
 
 	return unicodeHostname

--- a/lib/request-processor/helpers/normalizeHostname_test.go
+++ b/lib/request-processor/helpers/normalizeHostname_test.go
@@ -68,6 +68,16 @@ func TestNormalizeHostname(t *testing.T) {
 			input:    "example.com\u200B",
 			expected: "example.com",
 		},
+		{
+			name:     "FQDN with trailing dot",
+			input:    "example.com.",
+			expected: "example.com",
+		},
+		{
+			name:     "GCP IMDS hostname with trailing dot",
+			input:    "metadata.google.internal.",
+			expected: "metadata.google.internal",
+		},
 	}
 
 	for _, tt := range tests {

--- a/lib/request-processor/vulnerabilities/ssrf/imds.go
+++ b/lib/request-processor/vulnerabilities/ssrf/imds.go
@@ -1,6 +1,6 @@
 package ssrf
 
-import "strings"
+import "main/helpers"
 
 // This IP address is used by AWS EC2 instances to access the instance metadata service (IMDS)
 // We should block any requests to these IP addresses
@@ -26,8 +26,7 @@ func isIMDSIPAddress(ip string) bool {
 }
 
 func isTrustedHostname(hostname string) bool {
-	normalized := strings.ToLower(strings.TrimRight(hostname, "."))
-	_, exists := trustedHosts[normalized]
+	_, exists := trustedHosts[helpers.NormalizeHostname(hostname)]
 	return exists
 }
 

--- a/lib/request-processor/vulnerabilities/ssrf/imds.go
+++ b/lib/request-processor/vulnerabilities/ssrf/imds.go
@@ -1,5 +1,7 @@
 package ssrf
 
+import "strings"
+
 // This IP address is used by AWS EC2 instances to access the instance metadata service (IMDS)
 // We should block any requests to these IP addresses
 // This prevents STORED SSRF attacks that try to access the instance metadata service
@@ -24,8 +26,8 @@ func isIMDSIPAddress(ip string) bool {
 }
 
 func isTrustedHostname(hostname string) bool {
-	// Check if the hostname is in the trusted hosts map
-	_, exists := trustedHosts[hostname]
+	normalized := strings.ToLower(strings.TrimRight(hostname, "."))
+	_, exists := trustedHosts[normalized]
 	return exists
 }
 


### PR DESCRIPTION
## Summary

DNS resolvers sometimes return fully-qualified domain names with a trailing dot (e.g. `metadata.google.internal.`). The previous direct map lookup in `isTrustedHostname` did not match this form, so GCP IMDS requests could be incorrectly flagged as stored SSRF.

- Normalize with `strings.ToLower` + `strings.TrimRight(hostname, ".")` before the map lookup
- Add `"strings"` import

This is the same fix already applied in firewall-go (PR #459). Ported to Python, Ruby, .NET, PHP, and Java.

## Test plan
- [ ] Go tests in `lib/request-processor/` pass

<!-- AIKIDO_SECURITY_PR_SUMMARY_START -->
## Summary by Aikido
|  Security Issues: 0 | 🔍 Quality Issues: 1 |  Resolved Issues: 0 |
| :--- | :--- | :--- |


**🐛 Bugfixes**
* Normalized and trimmed trailing dots before trusted hostname comparison
* Stripped trailing dot in NormalizeHostname to handle FQDNs

**🔧 Refactors**
* Added helpers import and routed hostname checks through helper


<sup>[More info](https://app.aikido.dev/featurebranch/scan/128307466?groupId=6)</sup>
<!-- AIKIDO_SECURITY_PR_SUMMARY_END -->