### PR TITLE
fix: Sample apps build

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,6 @@
 # Docker container used for building Zen for PHP from source on Centos
 
-FROM ubuntu:20.04
+FROM ubuntu:24.04
 
 ARG PHP_VERSION=8.1
 

--- a/tools/sample_apps_build.sh
+++ b/tools/sample_apps_build.sh
@@ -72,7 +72,7 @@ curl -L -o $AIKIDO_INTERNALS_LIB $(curl -s $AIKIDO_INTERNALS_REPO/releases/lates
 mv $AIKIDO_INTERNALS_LIB $AIKIDO_INSTALL_PATH/$AIKIDO_INTERNALS_LIB
 
 chmod 755 $AIKIDO_INSTALL_PATH
-chmod 644 $AIKIDO_INSTALL_PATH/aikido-agent
+chmod 755 $AIKIDO_INSTALL_PATH/aikido-agent
 chmod 644 $AIKIDO_INSTALL_PATH/aikido-request-processor.so
 chmod 644 $(php -r 'echo ini_get("extension_dir");')/aikido.so
 

--- a/tools/sample_apps_build.sh
+++ b/tools/sample_apps_build.sh
@@ -45,9 +45,11 @@ sed -i "s/available_tags=''/available_tags='CXX'/" libtool
 if ! grep -q "BEGIN LIBTOOL TAG CONFIG: CXX" libtool; then
   sed -i '/^# ### BEGIN LIBTOOL TAG CONFIG: disable-shared$/i\
 # ### BEGIN LIBTOOL TAG CONFIG: CXX\
+CC="g++"\
 LTCXX="g++"\
 CXXFLAGS="-fPIC -g -O2"\
 compiler_CXX="g++"\
+compiler="g++"\
 # ### END LIBTOOL TAG CONFIG: CXX\
 ' libtool
 fi


### PR DESCRIPTION
ppa:ondrej/php no longer supports ubuntu 20

<!-- AIKIDO_SECURITY_PR_SUMMARY_START -->
## Summary by Aikido
|  Security Issues: 0 |  Quality Issues: 0 |  Resolved Issues: 0 |
| :--- | :--- | :--- |


**🐛 Bugfixes**
* Replaced Docker base image ubuntu:20.04 with ubuntu:24.04 to restore builds
* Changed aikido-agent file permission to be executable (chmod 755)


<sup>[More info](https://app.aikido.dev/featurebranch/scan/141631816?groupId=6)</sup>
<!-- AIKIDO_SECURITY_PR_SUMMARY_END -->