### PR TITLE
Increase rate-limiting timeout under high CPU load

### DIFF
--- a/lib/request-processor/handle_blocking_request.go
+++ b/lib/request-processor/handle_blocking_request.go
@@ -12,6 +12,9 @@ import (
 	"time"
 )
 
+// 50 ms is the lowest tested timeout that kept rate limiting working under heavy CPU load; shorter values can let requests through.
+const rateLimitingStatusTimeout = 50 * time.Millisecond
+
 func GetAction(actionHandling, actionType, trigger, description, data string, responseCode int) string {
 	actionMap := map[string]interface{}{
 		"action":        actionHandling,
@@ -64,7 +67,7 @@ func OnGetBlockingStatus(instance *instance.RequestProcessorInstance) string {
 		if method == "" || route == "" {
 			return ""
 		}
-		rateLimitingStatus := grpc.GetRateLimitingStatus(instance, server, method, route, routeParsed, userId, ip, rateLimitGroup, 10*time.Millisecond)
+		rateLimitingStatus := grpc.GetRateLimitingStatus(instance, server, method, route, routeParsed, userId, ip, rateLimitGroup, rateLimitingStatusTimeout)
 		if rateLimitingStatus != nil && rateLimitingStatus.Block {
 			context.ContextSetIsEndpointRateLimited(instance)
 			log.Infof(instance, "Request made from IP \"%s\" is ratelimited by \"%s\"!", ip, rateLimitingStatus.Trigger)


### PR DESCRIPTION
## What changed

- Increase the synchronous rate-limiting status timeout from 10 ms to 50 ms.
- Give the timeout a named constant and document why 50 ms was selected.

## Why

When the local rate-limiting status check exceeds its timeout, it returns no blocking decision and the request continues. Under high CPU load, the previous 10 ms limit was short enough for requests that should receive 429 responses to instead return 200.

50 ms was the lowest tested timeout that eliminated these timeout failures under the stress scenario while keeping the wait bounded.

## Validation

- Ran `go test ./...` for the request processor successfully.
- Ran the same eight rate-limiting Compose tests with 12 one-CPU load containers:

| Timeout | Tests passed | Timeout warnings |
| --- | ---: | ---: |
| 10 ms | 0/8 | 54 |
| 30 ms | 4/8 | 7 |
| 50 ms | 6/8 | 0 |

At 50 ms, the two remaining failures were unrelated to the timeout change: one existing excluded-user assertion and one demo-app startup/configuration-readiness failure.
