### PR TITLE
Use zen-demo-php default branch for QA

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -954,7 +954,6 @@ jobs:
         with:
           repository: Aikido-demo-apps/zen-demo-php
           path: zen-demo-php
-          ref: dev-testing
           submodules: recursive
 
       - name: Get Arch


### PR DESCRIPTION
## Summary

Remove the explicit `dev-testing` ref from the `zen-demo-php` checkout so the PHP QA job follows the demo repository's default branch.

## Why

The required firewall QA behavior has been moved onto `zen-demo-php`'s maintained `main` branch in [Aikido-demo-apps/zen-demo-php#75](https://github.com/Aikido-demo-apps/zen-demo-php/pull/75). Keeping the workflow pinned to the long-lived `dev-testing` branch would preserve unnecessary divergence and stale fixture code.

## Validation

- confirmed the `zen-demo-php` remote default branch is `main`
- full pinned `firewall-tester-action@v1.0.3` PHP suite on the main-based fixture:
  - 25 passed
  - 3 configured skips
  - 0 failures
  - 0 timeouts
- validated the final JSON/form-data route consolidation with PHP 8.2 lint and Laravel route/input checks
- `git diff --check` passed
