### PR TITLE
Prepare 1.5.18 release

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,25 +39,25 @@ Prerequisites:
 
 ##### x86_64
 ```
-rpm -Uvh --oldpackage https://github.com/AikidoSec/firewall-php/releases/download/v1.5.17/aikido-php-firewall.x86_64.rpm
+rpm -Uvh --oldpackage https://github.com/AikidoSec/firewall-php/releases/download/v1.5.18/aikido-php-firewall.x86_64.rpm
 ```
 
 ##### arm64 / aarch64
 ```
-rpm -Uvh --oldpackage https://github.com/AikidoSec/firewall-php/releases/download/v1.5.17/aikido-php-firewall.aarch64.rpm
+rpm -Uvh --oldpackage https://github.com/AikidoSec/firewall-php/releases/download/v1.5.18/aikido-php-firewall.aarch64.rpm
 ```
 
 #### For Debian-based Systems (Debian, Ubuntu)
 
 ##### x86_64
 ```
-curl -L -O https://github.com/AikidoSec/firewall-php/releases/download/v1.5.17/aikido-php-firewall.x86_64.deb
+curl -L -O https://github.com/AikidoSec/firewall-php/releases/download/v1.5.18/aikido-php-firewall.x86_64.deb
 dpkg -i -E ./aikido-php-firewall.x86_64.deb
 ```
 
 ##### arm64 / aarch64
 ```
-curl -L -O https://github.com/AikidoSec/firewall-php/releases/download/v1.5.17/aikido-php-firewall.aarch64.deb
+curl -L -O https://github.com/AikidoSec/firewall-php/releases/download/v1.5.18/aikido-php-firewall.aarch64.deb
 dpkg -i -E ./aikido-php-firewall.aarch64.deb
 ```
 

--- a/docs/aws-elastic-beanstalk.md
+++ b/docs/aws-elastic-beanstalk.md
@@ -4,7 +4,7 @@
 ```
 commands:
   aikido-php-firewall:
-    command: "rpm -Uvh --oldpackage https://github.com/AikidoSec/firewall-php/releases/download/v1.5.17/aikido-php-firewall.x86_64.rpm"
+    command: "rpm -Uvh --oldpackage https://github.com/AikidoSec/firewall-php/releases/download/v1.5.18/aikido-php-firewall.x86_64.rpm"
     ignoreErrors: true
 
 files:

--- a/docs/fly-io.md
+++ b/docs/fly-io.md
@@ -32,7 +32,7 @@ Create a script to install the Aikido PHP Firewall during deployment:
 #!/usr/bin/env bash
 cd /tmp
 
-curl -L -O https://github.com/AikidoSec/firewall-php/releases/download/v1.5.17/aikido-php-firewall.x86_64.deb
+curl -L -O https://github.com/AikidoSec/firewall-php/releases/download/v1.5.18/aikido-php-firewall.x86_64.deb
 dpkg -i -E ./aikido-php-firewall.x86_64.deb
 ```
 

--- a/docs/laravel-forge.md
+++ b/docs/laravel-forge.md
@@ -8,7 +8,7 @@ You can get your token from the [Aikido Security Dashboard](https://help.aikido.
 
 Go to "Commands" and run the following by replacing the sudo password with the one that Forge displays when the server is created:
 ```
-curl -L -O https://github.com/AikidoSec/firewall-php/releases/download/v1.5.17/aikido-php-firewall.x86_64.deb && echo "YOUR_SUDO_PASSWORD_HERE" | sudo -S dpkg -i -E ./aikido-php-firewall.x86_64.deb && echo "YOUR_SUDO_PASSWORD_HERE" | sudo -S service php8.4-fpm restart
+curl -L -O https://github.com/AikidoSec/firewall-php/releases/download/v1.5.18/aikido-php-firewall.x86_64.deb && echo "YOUR_SUDO_PASSWORD_HERE" | sudo -S dpkg -i -E ./aikido-php-firewall.x86_64.deb && echo "YOUR_SUDO_PASSWORD_HERE" | sudo -S service php8.4-fpm restart
 ```
 
 ![Forge Commands](./forge-commands.png)

--- a/docs/laravel-octane-frankenphp.md
+++ b/docs/laravel-octane-frankenphp.md
@@ -8,7 +8,7 @@ You can get your token from the [Aikido Security Dashboard](https://help.aikido.
 
 `docker/version/Dockerfile`
 ```dockerfile
-ARG AIKIDO_VERSION=1.5.17
+ARG AIKIDO_VERSION=1.5.18
 
 RUN curl -L -o /tmp/aikido-php-firewall.deb \
     "https://github.com/AikidoSec/firewall-php/releases/download/v${AIKIDO_VERSION}/aikido-php-firewall.$(uname -m).deb" \
@@ -72,7 +72,7 @@ dpkg -i -E ./aikido-php-firewall.$(uname -m).deb
 ```dockerfile
 FROM dunglas/frankenphp:php${PHP_VERSION}-bookworm
 
-ARG AIKIDO_VERSION=1.5.17
+ARG AIKIDO_VERSION=1.5.18
 
 RUN apt-get update && apt-get install -y curl \
     && curl -L -o /tmp/aikido-php-firewall.deb \

--- a/lib/agent/constants/constants.go
+++ b/lib/agent/constants/constants.go
@@ -1,7 +1,7 @@
 package constants
 
 const (
-	Version                             = "1.5.17"
+	Version                             = "1.5.18"
 	SocketPath                          = "/run/aikido-" + Version + "/aikido-agent.sock"
 	PidPath                             = "/run/aikido-" + Version + "/aikido-agent.pid"
 	ConfigUpdatedAtMethod               = "GET"

--- a/lib/php-extension/include/php_aikido.h
+++ b/lib/php-extension/include/php_aikido.h
@@ -19,7 +19,7 @@
 extern zend_module_entry aikido_module_entry;
 #define phpext_aikido_ptr &aikido_module_entry
 
-#define PHP_AIKIDO_VERSION "1.5.17"
+#define PHP_AIKIDO_VERSION "1.5.18"
 
 #if defined(ZTS) && defined(COMPILE_DL_AIKIDO)
 ZEND_TSRMLS_CACHE_EXTERN()

--- a/lib/request-processor/globals/globals.go
+++ b/lib/request-processor/globals/globals.go
@@ -79,6 +79,6 @@ func CreateServer(token string) *ServerData {
 }
 
 const (
-	Version    = "1.5.17"
+	Version    = "1.5.18"
 	SocketPath = "/run/aikido-" + Version + "/aikido-agent.sock"
 )

--- a/package/rpm/aikido.spec
+++ b/package/rpm/aikido.spec
@@ -1,5 +1,5 @@
 Name:           aikido-php-firewall
-Version:        1.5.17
+Version:        1.5.18
 Release:        1
 Summary:        Aikido PHP Extension
 License:        GPL


### PR DESCRIPTION
## What changed

- bump the PHP extension, agent, request processor, and RPM package versions to `1.5.18`
- update every installation example and documentation link to `v1.5.18`

## Why

The immutable `v1.5.17` release was published before its workflow could attach the generated packages and cannot be repaired. A new patch version is required.

## Validation

- confirmed all 13 release references use `1.5.18`
- confirmed no stale `1.5.17` release references remain in the established release-bump paths
- ran `git diff --check`
- confirmed this PR contains only the established nine-file version bump and no workflow changes
