### PR TITLE
Fix server PID tracking and prevent premature cleanup

### DIFF
--- a/lib/agent/main.go
+++ b/lib/agent/main.go
@@ -41,6 +41,8 @@ func serversCleanupRoutine(_ *ServerData) {
 		}
 		now := utils.GetTime()
 		lastConnectionTime := atomic.LoadInt64(&server.LastConnectionTime)
+		// Container platforms such as Google Cloud Run can suspend CPU between requests
+		// while keeping PHP alive. Only unregister after the process exits.
 		if now-lastConnectionTime > constants.MinServerInactivityForCleanup && !isProcessAlive(serverKey.ServerPID) {
 			log.InfofMainAndServer(server.Logger, "Server \"AIK_RUNTIME_***%s\" (server PID: %d) has been inactive for more than 2 minutes, unregistering...", utils.AnonymizeToken(serverKey.Token), serverKey.ServerPID)
 			server_utils.Unregister(serverKey)

--- a/lib/agent/main.go
+++ b/lib/agent/main.go
@@ -2,6 +2,7 @@ package main
 
 import (
 	"C"
+	"errors"
 	. "main/aikido_types"
 	"main/globals"
 	"main/grpc"
@@ -23,6 +24,15 @@ import (
 var serversCleanupChannel = make(chan struct{})
 var serversCleanupTicker = time.NewTicker(time.Minute)
 
+func isProcessAlive(pid int32) bool {
+	if pid <= 0 {
+		return false
+	}
+
+	err := syscall.Kill(int(pid), 0)
+	return err == nil || errors.Is(err, syscall.EPERM)
+}
+
 func serversCleanupRoutine(_ *ServerData) {
 	for _, serverKey := range globals.GetServersKeys() {
 		server := globals.GetServer(serverKey)
@@ -31,7 +41,7 @@ func serversCleanupRoutine(_ *ServerData) {
 		}
 		now := utils.GetTime()
 		lastConnectionTime := atomic.LoadInt64(&server.LastConnectionTime)
-		if now-lastConnectionTime > constants.MinServerInactivityForCleanup {
+		if now-lastConnectionTime > constants.MinServerInactivityForCleanup && !isProcessAlive(serverKey.ServerPID) {
 			log.InfofMainAndServer(server.Logger, "Server \"AIK_RUNTIME_***%s\" (server PID: %d) has been inactive for more than 2 minutes, unregistering...", utils.AnonymizeToken(serverKey.Token), serverKey.ServerPID)
 			server_utils.Unregister(serverKey)
 		}

--- a/lib/php-extension/PhpLifecycle.cpp
+++ b/lib/php-extension/PhpLifecycle.cpp
@@ -1,13 +1,15 @@
 #include "Includes.h"
 
 void PhpLifecycle::ModuleInit() {
+    this->mainPID = getpid();
+    requestProcessor.serverPID = this->mainPID;
+
     /* If SAPI name is "cli" run in "simple" mode */
     if (AIKIDO_GLOBAL(sapi_name) == "cli") {
         AIKIDO_LOG_INFO("MINIT finished earlier because we run in CLI mode!\n");
         return;
     }
 
-    this->mainPID = getpid();
     AIKIDO_LOG_INFO("Main PID is: %u\n", this->mainPID);
     if (!AIKIDO_GLOBAL(agent).Init()) {
         AIKIDO_LOG_INFO("Aikido Agent initialization failed!\n");

--- a/lib/php-extension/RequestProcessor.cpp
+++ b/lib/php-extension/RequestProcessor.cpp
@@ -62,7 +62,7 @@ bool RequestProcessor::Init() {
         return false;
     }
 
-    if (!requestProcessorInitFn(GoCreateString(AIKIDO_GLOBAL(sapi_name)))) {
+    if (!requestProcessorInitFn(GoCreateString(AIKIDO_GLOBAL(sapi_name)), static_cast<GoInt32>(this->serverPID))) {
         AIKIDO_LOG_ERROR("Failed to initialize Aikido Request Processor!\n");
         this->initFailed = true;
         return false;

--- a/lib/php-extension/include/RequestProcessor.h
+++ b/lib/php-extension/include/RequestProcessor.h
@@ -5,7 +5,7 @@ typedef GoUint8 (*InitInstanceFn)(void* instancePtr, GoString initJson);
 typedef void (*DestroyInstanceFn)(uint64_t threadId);
 
 // Updated typedefs with instance pointer as first parameter
-typedef GoUint8 (*RequestProcessorInitFn)(GoString platformName);
+typedef GoUint8 (*RequestProcessorInitFn)(GoString platformName, GoInt32 serverPID);
 typedef GoUint8 (*RequestProcessorContextInitFn)(void* instancePtr, ContextCallback);
 typedef GoUint8 (*RequestProcessorConfigUpdateFn)(void* instancePtr, GoString initJson);
 typedef char* (*RequestProcessorOnEventFn)(void* instancePtr, GoInt eventId);
@@ -22,6 +22,7 @@ class RequestProcessor {
     public:
     bool initFailed = false;
     void* libHandle = nullptr;
+    pid_t serverPID = 0;
 
     CreateInstanceFn createInstanceFn = nullptr;
     InitInstanceFn initInstanceFn = nullptr;

--- a/lib/request-processor/config/config.go
+++ b/lib/request-processor/config/config.go
@@ -62,21 +62,8 @@ func ReloadAikidoConfig(instance *instance.RequestProcessorInstance, conf *Aikid
 	return ReloadWithNewToken
 }
 
-func getServerPID(platformName string) int32 {
-	switch platformName {
-	case "fpm-fcgi", "apache2handler":
-		// Use the parent PID when requests execute in replaceable child processes beneath a persistent master.
-		return int32(os.Getppid())
-	case "cli-server", "frankenphp":
-		// Use the current PID when the request-handling process is itself the persistent server.
-		return int32(os.Getpid())
-	default:
-		return int32(os.Getpid())
-	}
-}
-
-func Init(platformName string) {
-	globals.EnvironmentConfig.ServerPID = getServerPID(platformName)
+func Init(platformName string, serverPID int32) {
+	globals.EnvironmentConfig.ServerPID = serverPID
 	globals.EnvironmentConfig.RequestProcessorPID = int32(os.Getpid())
 	globals.EnvironmentConfig.PlatformName = platformName
 }

--- a/lib/request-processor/config/config.go
+++ b/lib/request-processor/config/config.go
@@ -62,8 +62,21 @@ func ReloadAikidoConfig(instance *instance.RequestProcessorInstance, conf *Aikid
 	return ReloadWithNewToken
 }
 
+func getServerPID(platformName string) int32 {
+	switch platformName {
+	case "fpm-fcgi", "apache2handler":
+		// Requests run in child processes that share a stable server master.
+		return int32(os.Getppid())
+	case "cli-server", "frankenphp":
+		// Requests run in the server process itself.
+		return int32(os.Getpid())
+	default:
+		return int32(os.Getpid())
+	}
+}
+
 func Init(platformName string) {
-	globals.EnvironmentConfig.ServerPID = int32(os.Getppid())
+	globals.EnvironmentConfig.ServerPID = getServerPID(platformName)
 	globals.EnvironmentConfig.RequestProcessorPID = int32(os.Getpid())
 	globals.EnvironmentConfig.PlatformName = platformName
 }

--- a/lib/request-processor/config/config.go
+++ b/lib/request-processor/config/config.go
@@ -65,10 +65,10 @@ func ReloadAikidoConfig(instance *instance.RequestProcessorInstance, conf *Aikid
 func getServerPID(platformName string) int32 {
 	switch platformName {
 	case "fpm-fcgi", "apache2handler":
-		// Requests run in child processes that share a stable server master.
+		// Use the parent PID when requests execute in replaceable child processes beneath a persistent master.
 		return int32(os.Getppid())
 	case "cli-server", "frankenphp":
-		// Requests run in the server process itself.
+		// Use the current PID when the request-handling process is itself the persistent server.
 		return int32(os.Getpid())
 	default:
 		return int32(os.Getpid())

--- a/lib/request-processor/config/config_test.go
+++ b/lib/request-processor/config/config_test.go
@@ -1,32 +1,21 @@
 package config
 
 import (
-	"os"
+	"main/globals"
 	"testing"
 )
 
-func TestGetServerPID(t *testing.T) {
-	currentPID := int32(os.Getpid())
-	parentPID := int32(os.Getppid())
+func TestInitUsesServerPIDFromExtension(t *testing.T) {
+	previousConfig := globals.EnvironmentConfig
+	t.Cleanup(func() {
+		globals.EnvironmentConfig = previousConfig
+	})
 
-	tests := []struct {
-		name         string
-		platformName string
-		expectedPID  int32
-	}{
-		{name: "PHP-FPM uses its master", platformName: "fpm-fcgi", expectedPID: parentPID},
-		{name: "Apache uses its master", platformName: "apache2handler", expectedPID: parentPID},
-		{name: "PHP built-in server uses itself", platformName: "cli-server", expectedPID: currentPID},
-		{name: "FrankenPHP uses itself", platformName: "frankenphp", expectedPID: currentPID},
-		{name: "unknown SAPI uses itself", platformName: "unknown", expectedPID: currentPID},
-	}
+	const platformName = "test-sapi"
+	const serverPID int32 = 1234
+	Init(platformName, serverPID)
 
-	for _, test := range tests {
-		t.Run(test.name, func(t *testing.T) {
-			actualPID := getServerPID(test.platformName)
-			if actualPID != test.expectedPID {
-				t.Fatalf("getServerPID(%q) = %d, expected %d", test.platformName, actualPID, test.expectedPID)
-			}
-		})
+	if globals.EnvironmentConfig.ServerPID != serverPID {
+		t.Fatalf("ServerPID = %d, expected %d", globals.EnvironmentConfig.ServerPID, serverPID)
 	}
 }

--- a/lib/request-processor/config/config_test.go
+++ b/lib/request-processor/config/config_test.go
@@ -1,0 +1,32 @@
+package config
+
+import (
+	"os"
+	"testing"
+)
+
+func TestGetServerPID(t *testing.T) {
+	currentPID := int32(os.Getpid())
+	parentPID := int32(os.Getppid())
+
+	tests := []struct {
+		name         string
+		platformName string
+		expectedPID  int32
+	}{
+		{name: "PHP-FPM uses its master", platformName: "fpm-fcgi", expectedPID: parentPID},
+		{name: "Apache uses its master", platformName: "apache2handler", expectedPID: parentPID},
+		{name: "PHP built-in server uses itself", platformName: "cli-server", expectedPID: currentPID},
+		{name: "FrankenPHP uses itself", platformName: "frankenphp", expectedPID: currentPID},
+		{name: "unknown SAPI uses itself", platformName: "unknown", expectedPID: currentPID},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			actualPID := getServerPID(test.platformName)
+			if actualPID != test.expectedPID {
+				t.Fatalf("getServerPID(%q) = %d, expected %d", test.platformName, actualPID, test.expectedPID)
+			}
+		})
+	}
+}

--- a/lib/request-processor/main.go
+++ b/lib/request-processor/main.go
@@ -80,7 +80,7 @@ func DestroyInstance(threadID uint64) {
 }
 
 //export RequestProcessorInit
-func RequestProcessorInit(platformName string) (initOk bool) {
+func RequestProcessorInit(platformName string, serverPID int32) (initOk bool) {
 	defer func() {
 		if r := recover(); r != nil {
 			log.Warn(nil, "Recovered from panic:", r)
@@ -88,7 +88,7 @@ func RequestProcessorInit(platformName string) (initOk bool) {
 		}
 	}()
 
-	config.Init(platformName)
+	config.Init(platformName, serverPID)
 
 	if globals.EnvironmentConfig.PlatformName != "cli" {
 		grpc.Init()


### PR DESCRIPTION
## Summary

Prevent inactive connections from causing live PHP server registrations to be removed. Cleanup now unregisters a server only when it has exceeded the existing inactivity threshold and its lifecycle process no longer exists.

The PHP extension captures the server PID once during module startup and passes it directly to the Go request processor. This avoids inferring the lifecycle process from the SAPI or parent PID, including container PID 1 cases where the parent PID is 0.

## Validation

- Go tests, vet, and production builds passed.
- PHP 8.2 NTS/ZTS and PHP 8.5 Apache-compatible extension builds passed.
- Verified the captured PID with PHP-FPM, Apache mod_php, PHP's built-in server, and FrankenPHP classic and worker modes.
- Pausing an FPM container for 130 seconds did not remove its live registration.
- Stopping all FPM workers for more than three minutes retained the registration while the master remained alive.
- Killing the FPM master removed its stale registration on the next cleanup tick.