### PR TITLE
Prevent initial cloud sync from blocking PHP workers

### DIFF
--- a/lib/agent/aikido_types/init_data.go
+++ b/lib/agent/aikido_types/init_data.go
@@ -250,6 +250,10 @@ func NewServerData() *ServerData {
 		UsersQueue:              NewQueue[string](MaxNumberOfStoredUsers),
 		Packages:                make(map[string]Package),
 		PollingData:             NewServerDataPolling(),
+		StatsData: StatsDataType{
+			StartedAt:            time.Now().UnixMilli(),
+			MonitoredSinkTimings: make(map[string]MonitoredSinkTimings),
+		},
 		AttackWave: AttackWaveState{
 			Threshold:       15,             // Default: 15 requests
 			WindowSize:      1,              // Default: 1 minute

--- a/lib/agent/cloud/cloud.go
+++ b/lib/agent/cloud/cloud.go
@@ -6,9 +6,6 @@ import (
 )
 
 func Init(server *ServerData) {
-	server.StatsData.StartedAt = utils.GetTime()
-	server.StatsData.MonitoredSinkTimings = make(map[string]MonitoredSinkTimings)
-
 	CheckConfigUpdatedAt(server)
 
 	utils.StartPollingRoutine(server.PollingData.HeartbeatRoutineChannel, server.PollingData.HeartbeatTicker, SendHeartbeatEvent, server)

--- a/lib/agent/server_utils/server.go
+++ b/lib/agent/server_utils/server.go
@@ -31,9 +31,9 @@ func storeConfig(server *ServerData, req *protos.Config) {
 
 func Register(serverKey ServerKey, requestProcessorPID int32, req *protos.Config) {
 	globals.ServersMutex.Lock()
-	defer globals.ServersMutex.Unlock()
 	server, exists := globals.GetOrCreateServer(serverKey)
 	if exists {
+		globals.ServersMutex.Unlock()
 		log.Debugf(log.MainLogger, "Server \"AIK_RUNTIME_***%s\" already exists, skipping registration (request processor PID: %d, server PID: %d)", utils.AnonymizeToken(serverKey.Token), requestProcessorPID, serverKey.ServerPID)
 		return
 	}
@@ -46,8 +46,14 @@ func Register(serverKey ServerKey, requestProcessorPID int32, req *protos.Config
 
 	atomic.StoreInt64(&server.LastConnectionTime, utils.GetTime())
 
+	wasPastDeleted := globals.IsPastDeletedServer(serverKey)
+
+	// PHP workers can use the local server state before the initial cloud sync
+	// finishes. Holding this lock would make them wait for network I/O and time out.
+	globals.ServersMutex.Unlock()
+
 	cloud.Init(server)
-	if globals.IsPastDeletedServer(serverKey) {
+	if wasPastDeleted {
 		log.InfofMainAndServer(server.Logger, "Server \"AIK_RUNTIME_***%s\" (server PID: %d) was registered before for this server PID, but deleted due to inactivity! Skipping start event as it was sent before...", utils.AnonymizeToken(serverKey.Token), serverKey.ServerPID)
 	} else {
 		cloud.SendStartEvent(server)

--- a/lib/agent/server_utils/server_test.go
+++ b/lib/agent/server_utils/server_test.go
@@ -1,0 +1,104 @@
+package server_utils
+
+import (
+	"main/aikido_types"
+	"main/globals"
+	"main/ipc/protos"
+	"main/log"
+	"net/http"
+	"net/http/httptest"
+	"sync"
+	"testing"
+	"time"
+)
+
+func TestRegisterDoesNotBlockServerLookupsDuringCloudRequest(t *testing.T) {
+	log.Init()
+	t.Cleanup(log.Uninit)
+
+	cloudRequestStarted := make(chan struct{})
+	releaseCloudRequest := make(chan struct{})
+	var releaseOnce sync.Once
+	release := func() { releaseOnce.Do(func() { close(releaseCloudRequest) }) }
+
+	cloudServer := httptest.NewServer(http.HandlerFunc(func(response http.ResponseWriter, request *http.Request) {
+		if request.URL.Path == "/config" {
+			select {
+			case <-cloudRequestStarted:
+			default:
+				close(cloudRequestStarted)
+			}
+			<-releaseCloudRequest
+			response.Header().Set("Content-Type", "application/json")
+			_, _ = response.Write([]byte(`{"configUpdatedAt":0}`))
+			return
+		}
+
+		response.Header().Set("Content-Type", "application/json")
+		_, _ = response.Write([]byte(`{}`))
+	}))
+
+	serverKey := aikido_types.ServerKey{Token: "AIK_RUNTIME_TEST", ServerPID: 12345}
+	request := &protos.Config{
+		Token:          serverKey.Token,
+		ServerPid:      serverKey.ServerPID,
+		Endpoint:       cloudServer.URL,
+		ConfigEndpoint: cloudServer.URL,
+		LogLevel:       "ERROR",
+	}
+
+	registerDone := make(chan struct{})
+	go func() {
+		Register(serverKey, 54321, request)
+		close(registerDone)
+	}()
+
+	t.Cleanup(func() {
+		release()
+		select {
+		case <-registerDone:
+		case <-time.After(2 * time.Second):
+		}
+		if globals.GetServer(serverKey) != nil {
+			Unregister(serverKey)
+		}
+		globals.ServersMutex.Lock()
+		delete(globals.PastDeletedServers, serverKey)
+		globals.ServersMutex.Unlock()
+		cloudServer.Close()
+	})
+
+	select {
+	case <-cloudRequestStarted:
+	case <-time.After(2 * time.Second):
+		t.Fatal("registration did not reach the cloud request")
+	}
+
+	lookupDone := make(chan *aikido_types.ServerData, 1)
+	go func() { lookupDone <- globals.GetServer(serverKey) }()
+
+	select {
+	case server := <-lookupDone:
+		if server == nil {
+			t.Fatal("registered server was not visible during the cloud request")
+		}
+		if server.StatsData.StartedAt == 0 || server.StatsData.MonitoredSinkTimings == nil {
+			t.Fatal("registered server was visible before its local state was initialized")
+		}
+	case <-time.After(250 * time.Millisecond):
+		t.Fatal("server lookup was blocked by the cloud request")
+	}
+
+	select {
+	case <-registerDone:
+		t.Fatal("registration completed before the stalled cloud request was released")
+	default:
+	}
+
+	release()
+	select {
+	case <-registerDone:
+	case <-time.After(2 * time.Second):
+		t.Fatal("registration did not complete after the cloud request was released")
+	}
+}


### PR DESCRIPTION
## Summary

- release the server map lock before the initial cloud sync
- keep local server state ready for concurrent PHP workers
- cover a stalled config request with a regression test

## Testing

- `go test ./server_utils -run "^TestRegisterDoesNotBlockServerLookupsDuringCloudRequest$" -count=1 -v`
- `go test -race ./server_utils -run "^TestRegisterDoesNotBlockServerLookupsDuringCloudRequest$" -count=10`
- `go test ./...`