### PR TITLE
Fix missing PHP extension logs when disk logging is disabled

### DIFF
--- a/docs/troubleshooting.md
+++ b/docs/troubleshooting.md
@@ -17,7 +17,21 @@ Test from the same environment where your app runs and follow the instructions o
 
 ## Check logs for errors
 
-`cat /var/log/aikido-*/*`
+The agent writes its main log to `/var/log/aikido-<version>/aikido-agent-*-main.log`:
+
+```sh
+cat /var/log/aikido-*/aikido-agent-*-main.log
+```
+
+`AIKIDO_DISK_LOGS` is disabled by default. With the default configuration, check both the main agent log above and your PHP, web server, or container logs for Zen warnings and errors.
+
+For additional troubleshooting, set `AIKIDO_DISK_LOGS=1`. Zen will then write additional logs under `/var/log/aikido-<version>/`. `AIKIDO_LOG_LEVEL` controls which messages are included, defaults to `WARN`, and supports `DEBUG`, `INFO`, `WARN`, and `ERROR`.
+
+Restart the service or container running your application after changing either `AIKIDO_DISK_LOGS` or `AIKIDO_LOG_LEVEL` so that every running process uses the new setting.
+
+```sh
+cat /var/log/aikido-*/*
+```
 
 ## Check if Aikido module has enabled
 

--- a/docs/troubleshooting.md
+++ b/docs/troubleshooting.md
@@ -25,6 +25,8 @@ cat /var/log/aikido-*/aikido-agent-*-main.log
 
 `AIKIDO_DISK_LOGS` is disabled by default. With the default configuration, check both the main agent log above and your PHP, web server, or container logs for Zen warnings and errors.
 
+When using PHP-FPM, set [`catch_workers_output = yes`](https://www.php.net/manual/en/install.fpm.configuration.php) in the PHP-FPM pool configuration and restart PHP-FPM so Zen warnings and errors are included in its logs. This setting is disabled by default.
+
 For additional troubleshooting, set `AIKIDO_DISK_LOGS=1`. Zen will then write additional logs under `/var/log/aikido-<version>/`. `AIKIDO_LOG_LEVEL` controls which messages are included, defaults to `WARN`, and supports `DEBUG`, `INFO`, `WARN`, and `ERROR`.
 
 Restart the service or container running your application after changing either `AIKIDO_DISK_LOGS` or `AIKIDO_LOG_LEVEL` so that every running process uses the new setting.

--- a/lib/php-extension/Hooks.cpp
+++ b/lib/php-extension/Hooks.cpp
@@ -85,7 +85,7 @@ void HookFunctions() {
     for (auto &it : HOOKED_FUNCTIONS) {
         zend_function *function_data = (zend_function *)zend_hash_str_find_ptr(CG(function_table), it.first.c_str(), it.first.length());
         if (!function_data) {
-            AIKIDO_LOG_WARN("Function \"%s\" does not exist!\n", it.first.c_str());
+            AIKIDO_LOG_INFO("Function \"%s\" does not exist!\n", it.first.c_str());
             continue;
         }
         if (it.second.original_handler) {
@@ -103,7 +103,7 @@ void UnhookFunctions() {
     for (auto &it : HOOKED_FUNCTIONS) {
         zend_function *function_data = (zend_function *)zend_hash_str_find_ptr(CG(function_table), it.first.c_str(), it.first.length());
         if (!function_data) {
-            AIKIDO_LOG_WARN("Function \"%s\" does not exist!\n", it.first.c_str());
+            AIKIDO_LOG_INFO("Function \"%s\" does not exist!\n", it.first.c_str());
             continue;
         }
         if (!it.second.original_handler) {
@@ -120,13 +120,13 @@ void HookMethods() {
     for (auto &it : HOOKED_METHODS) {
         zend_class_entry *class_entry = (zend_class_entry *)zend_hash_str_find_ptr(CG(class_table), it.first.class_name.c_str(), it.first.class_name.length());
         if (!class_entry) {
-            AIKIDO_LOG_WARN("Class \"%s\" does not exist!\n", it.first.class_name.c_str());
+            AIKIDO_LOG_INFO("Class \"%s\" does not exist!\n", it.first.class_name.c_str());
             continue;
         }
 
         zend_function *method = (zend_function *)zend_hash_str_find_ptr(&class_entry->function_table, it.first.method_name.c_str(), it.first.method_name.length());
         if (!method) {
-            AIKIDO_LOG_WARN("Method \"%s->%s\" does not exist!\n", it.first.class_name.c_str(), it.first.method_name.c_str());
+            AIKIDO_LOG_INFO("Method \"%s->%s\" does not exist!\n", it.first.class_name.c_str(), it.first.method_name.c_str());
             continue;
         }
 
@@ -145,13 +145,13 @@ void UnhookMethods() {
     for (auto &it : HOOKED_METHODS) {
         zend_class_entry *class_entry = (zend_class_entry *)zend_hash_str_find_ptr(CG(class_table), it.first.class_name.c_str(), it.first.class_name.length());
         if (!class_entry) {
-            AIKIDO_LOG_WARN("Class \"%s\" does not exist!\n", it.first.class_name.c_str());
+            AIKIDO_LOG_INFO("Class \"%s\" does not exist!\n", it.first.class_name.c_str());
             continue;
         }
 
         zend_function *method = (zend_function *)zend_hash_str_find_ptr(&class_entry->function_table, it.first.method_name.c_str(), it.first.method_name.length());
         if (!method) {
-            AIKIDO_LOG_WARN("Method \"%s->%s\" does not exist!\n", it.first.class_name.c_str(), it.first.method_name.c_str());
+            AIKIDO_LOG_INFO("Method \"%s->%s\" does not exist!\n", it.first.class_name.c_str(), it.first.method_name.c_str());
             continue;
         }
 

--- a/lib/php-extension/Log.cpp
+++ b/lib/php-extension/Log.cpp
@@ -28,12 +28,17 @@ void Log::Write(AIKIDO_LOG_LEVEL level, const char* format, ...) {
         return;
     }
 
-    FILE* logFile = stdout;
-    if (AIKIDO_GLOBAL(disk_logs)) {
-        logFile = this->logFile;
+    FILE* logFile = this->logFile;
+    if (!AIKIDO_GLOBAL(disk_logs)) {
+        // Keep verbose extension logs opt-in via disk logging. Warnings and
+        // errors still need a default destination for container observability.
+        if (level < AIKIDO_LOG_LEVEL_WARN) {
+            return;
+        }
+        logFile = stderr;
     }
 
-    if (!this->logFile) {
+    if (!logFile) {
         return;
     }
 

--- a/lib/php-extension/include/php_aikido.h
+++ b/lib/php-extension/include/php_aikido.h
@@ -30,7 +30,7 @@ bool environment_loaded;
 long log_level;
 bool blocking;
 bool disable;
-bool disk_logs; // When enabled, it writes logs to disk instead of stdout. It's usefull when debugging to have the logs grouped by PHP process.
+bool disk_logs; // When enabled, all configured log levels are written to disk. Otherwise, warnings and errors are written to stderr.
 bool collect_api_schema;
 // When enabled, the Agent listens for cloud config updates over a Server-Sent Events stream, on top of polling.
 bool sse;

--- a/tests/cli/aikido_ops/test_extension_logs_without_disk_logs.phpt
+++ b/tests/cli/aikido_ops/test_extension_logs_without_disk_logs.phpt
@@ -1,0 +1,16 @@
+--TEST--
+PHP extension logs errors when disk logs are disabled
+
+--ENV--
+AIKIDO_LOG_LEVEL=ERROR
+AIKIDO_DISK_LOGS=0
+
+--FILE--
+<?php
+
+\aikido\set_token("");
+
+?>
+
+--EXPECTREGEX--
+.*\[AIKIDO\]\[ERROR\]\[\d+\]\[\d+\]\[[0-9:]+\] set_token: token is null!.*


### PR DESCRIPTION
## Why

`AIKIDO_DISK_LOGS` is disabled by default. In that mode, the PHP extension logger selected `stdout` as its destination but then checked whether its disk-log file was open. Because no disk file is created when disk logging is disabled, `Log::Write` returned without writing anything.

As a result, every PHP extension warning and error was silent by default, including failures to load or initialize the request processor, failures to start the agent process, and exceptions inside protection handlers. These are the messages users need when the extension is not working.

## What changes

| Configuration | PHP extension behavior |
| --- | --- |
| Disk logging disabled, INFO or DEBUG | No output |
| Disk logging disabled, WARN or ERROR | Write to `stderr` |
| Disk logging enabled | Continue writing configured log levels to the per-process disk log |

The configured `AIKIDO_LOG_LEVEL` threshold still applies. `stderr` is used instead of `stdout` so extension diagnostics do not become normal PHP or CLI output and remain visible in container, FPM, and web-server logs.

## Why the hook messages become INFO

Making warnings visible would also expose existing messages for hook targets that are not installed, such as PostgreSQL, MySQLi, PDO, or cURL functions and classes. Missing optional APIs are expected and do not mean the agent is malfunctioning, so those messages are changed from WARN to INFO. They remain available in verbose disk logs, while genuine hook conflicts and initialization failures remain WARN or ERROR.

## Documentation

Updates the troubleshooting guide to explain where to find Zen logs by default, how to enable additional logs with `AIKIDO_DISK_LOGS`, how `AIKIDO_LOG_LEVEL` affects their contents, and when the service or container must be restarted.

## Validation

Adds PHPT regression coverage proving that an extension error is emitted when disk logging is disabled.

Validated with a PHP 8.5 extension build, all 6 targeted `aikido_ops` tests, and a broad CLI run where 78 passed, 1 skipped, and only the 11 PostgreSQL cases could not run because the local image lacks `pg_connect`. All 238 GitHub CI jobs passed.