### PR TITLE
Add Alpine musl support with a custom Go toolchain

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,4 +1,6 @@
 build
+package-input
+apk-out
 lib/php-extension/build
 lib/php-extension/autom4te.cache
 lib/php-extension/config.h.in

--- a/.github/workflows/Dockerfile.build-extension-alpine
+++ b/.github/workflows/Dockerfile.build-extension-alpine
@@ -1,0 +1,74 @@
+# syntax=docker/dockerfile:1.7
+
+ARG ALPINE_VERSION=3.22
+ARG PHP_VERSION=8.4
+ARG PHP_ZTS=0
+
+FROM alpine:${ALPINE_VERSION} AS php-build
+
+ARG PHP_VERSION
+ARG PHP_ZTS
+ARG PHP_SRC_REF=PHP-${PHP_VERSION}
+
+RUN apk add --no-cache \
+    autoconf \
+    bison \
+    build-base \
+    ca-certificates \
+    curl-dev \
+    git \
+    linux-headers \
+    pkgconf \
+    re2c
+
+WORKDIR /usr/src
+RUN git clone --depth 1 --branch "${PHP_SRC_REF}" \
+      https://github.com/php/php-src.git
+
+WORKDIR /usr/src/php-src
+RUN ./buildconf --force && \
+    if [ "${PHP_ZTS}" = "1" ]; then \
+      ZTS_FLAGS="--enable-zts"; \
+    else \
+      ZTS_FLAGS="--disable-zts"; \
+    fi && \
+    ./configure \
+      --prefix=/usr/local \
+      --with-config-file-path=/usr/local/lib \
+      --with-config-file-scan-dir=/usr/local/etc/php/conf.d \
+      --disable-all \
+      --enable-cli \
+      --enable-pdo \
+      --without-pear \
+      ${ZTS_FLAGS} && \
+    make -j"$(nproc)" && \
+    make install
+
+FROM php-build AS extension-build
+
+ARG PHP_ZTS
+
+WORKDIR /workspace
+COPY . .
+
+RUN mkdir -p build/extension && \
+    cd lib/php-extension && \
+    phpize && \
+    cd ../../build/extension && \
+    CXX=g++ \
+    CXXFLAGS="-fPIC -g -O2 -I../../lib/php-extension/include" \
+    LDFLAGS="-lstdc++" \
+      ../../lib/php-extension/configure && \
+    make -j"$(nproc)" && \
+    mkdir -p /out && \
+    cp modules/aikido.so /out/aikido.so && \
+    file /out/aikido.so && \
+    if [ "${PHP_ZTS}" = "1" ]; then \
+      php -v | grep -q ZTS; \
+    else \
+      ! php -v | grep -q ZTS; \
+    fi && \
+    php -n -d extension=/out/aikido.so -m | grep -qx aikido
+
+FROM scratch AS artifact
+COPY --from=extension-build /out/aikido.so /

--- a/.github/workflows/Dockerfile.build-libs-alpine
+++ b/.github/workflows/Dockerfile.build-libs-alpine
@@ -1,0 +1,106 @@
+# syntax=docker/dockerfile:1.7
+
+FROM alpine:3.22@sha256:14358309a308569c32bdc37e2e0e9694be33a9d99e68afb0f5ff33cc1f695dce AS go-base
+
+ARG TARGETARCH
+ARG GO_VERSION=1.26.7
+ARG GO_AMD64_SHA256=ffb5f8de10c62550dfddab66b36b57030721e0a44a3218e9e1181d7b59f121ca
+ARG GO_ARM64_SHA256=5a4ec883379d51ee9ce1040d5e87f8d35e20387574dd8c947feb01eabc3c1b37
+
+RUN apk add --no-cache \
+    bash \
+    build-base \
+    ca-certificates \
+    curl \
+    file \
+    git \
+    protobuf \
+    protobuf-dev
+
+RUN case "${TARGETARCH}" in \
+      amd64) GO_SHA256="${GO_AMD64_SHA256}" ;; \
+      arm64) GO_SHA256="${GO_ARM64_SHA256}" ;; \
+      *) echo "Unsupported architecture: ${TARGETARCH}" >&2; exit 1 ;; \
+    esac && \
+    GO_ARCHIVE="go${GO_VERSION}.linux-${TARGETARCH}.tar.gz" && \
+    curl --fail --location --retry 3 \
+      --output "/tmp/${GO_ARCHIVE}" \
+      "https://go.dev/dl/${GO_ARCHIVE}" && \
+    echo "${GO_SHA256}  /tmp/${GO_ARCHIVE}" | sha256sum -c - && \
+    tar -C /usr/local -xzf "/tmp/${GO_ARCHIVE}" && \
+    rm "/tmp/${GO_ARCHIVE}"
+
+ENV GOPATH=/go \
+    GOBIN=/go/bin \
+    GOTOOLCHAIN=local \
+    PATH=/go/bin:/usr/local/go/bin:$PATH
+
+RUN go version
+
+FROM go-base AS go-source
+
+# GitHub PR #75048: cmd/link,runtime: fix c-shared dlopen on non-glibc systems.
+# Pin the exact reviewed source commit rather than the mutable PR branch.
+ARG GO_PR_REPOSITORY=https://github.com/jgowdy/go.git
+ARG GO_PR_COMMIT=1a087d05b5cf9573876b18812d8d5516f16bbe57
+
+RUN git init /usr/local/go-pr && \
+    cd /usr/local/go-pr && \
+    git remote add origin "${GO_PR_REPOSITORY}" && \
+    git fetch --depth 1 origin "${GO_PR_COMMIT}" && \
+    test "$(git rev-parse FETCH_HEAD)" = "${GO_PR_COMMIT}" && \
+    git checkout --detach FETCH_HEAD && \
+    cd src && \
+    GOROOT_BOOTSTRAP=/usr/local/go ./make.bash && \
+    /usr/local/go-pr/bin/go version && \
+    rm -rf /usr/local/go-pr/.git
+
+FROM go-base AS toolchain
+
+COPY --from=go-source /usr/local/go-pr /usr/local/go-pr
+
+RUN go install google.golang.org/protobuf/cmd/protoc-gen-go@v1.36.12 && \
+    go install google.golang.org/grpc/cmd/protoc-gen-go-grpc@v1.5.1
+
+FROM toolchain AS build
+
+WORKDIR /workspace
+COPY . .
+
+# Git symlinks are materialized as text files in some Windows checkouts.
+RUN if [ ! -L lib/agent/api_discovery/getDataSchema.go ]; then \
+      rm lib/agent/api_discovery/getDataSchema.go && \
+      ln -s ../../request-processor/api_discovery/getDataSchema.go \
+        lib/agent/api_discovery/getDataSchema.go; \
+    fi
+
+RUN mkdir -p build && \
+    cd lib && \
+    protoc --go_out=agent --go-grpc_out=agent ipc.proto && \
+    cd agent && \
+    go mod download && \
+    go mod verify && \
+    go test ./... && \
+    go build -buildvcs=false -ldflags "-s -w" \
+      -o ../../build/aikido-agent
+
+RUN cd lib && \
+    protoc --go_out=request-processor --go-grpc_out=request-processor ipc.proto && \
+    cd request-processor && \
+    go mod download && \
+    go mod verify && \
+    go test ./... && \
+    /usr/local/go-pr/bin/go build -buildvcs=false -ldflags "-s -w" -buildmode=c-shared \
+      -o ../../build/aikido-request-processor.so
+
+RUN cc tools/dlopen-smoke.c -ldl -o /tmp/dlopen-smoke && \
+    /tmp/dlopen-smoke build/aikido-request-processor.so && \
+    file build/aikido-agent build/aikido-request-processor.so && \
+    /usr/local/go-pr/bin/go version && \
+    go version -m build/aikido-agent && \
+    go version -m build/aikido-request-processor.so
+
+FROM scratch AS artifacts
+COPY --from=build /workspace/build/aikido-agent /
+COPY --from=build /workspace/build/aikido-request-processor.h /
+COPY --from=build /workspace/build/aikido-request-processor.so /

--- a/.github/workflows/Dockerfile.build-libs-alpine
+++ b/.github/workflows/Dockerfile.build-libs-alpine
@@ -59,7 +59,12 @@ FROM go-base AS toolchain
 
 COPY --from=go-source /usr/local/go-pr /usr/local/go-pr
 
-RUN go install google.golang.org/protobuf/cmd/protoc-gen-go@v1.36.12 && \
+# Use the pinned PR toolchain for every Go command in the Alpine build. The
+# official release above is only the bootstrap compiler used by make.bash.
+ENV PATH=/usr/local/go-pr/bin:/go/bin:/usr/local/go/bin:$PATH
+
+RUN go version && \
+    go install google.golang.org/protobuf/cmd/protoc-gen-go@v1.36.12 && \
     go install google.golang.org/grpc/cmd/protoc-gen-go-grpc@v1.5.1
 
 FROM toolchain AS build
@@ -80,8 +85,8 @@ RUN mkdir -p build && \
     cd agent && \
     go mod download && \
     go mod verify && \
-    go test ./... && \
-    go build -buildvcs=false -ldflags "-s -w" \
+    go test -ldflags "-linkmode=external" ./... && \
+    go build -buildvcs=false -ldflags "-s -w -linkmode=external" \
       -o ../../build/aikido-agent
 
 RUN cd lib && \
@@ -89,14 +94,14 @@ RUN cd lib && \
     cd request-processor && \
     go mod download && \
     go mod verify && \
-    go test ./... && \
-    /usr/local/go-pr/bin/go build -buildvcs=false -ldflags "-s -w" -buildmode=c-shared \
+    go test -ldflags "-linkmode=external" ./... && \
+    go build -buildvcs=false -ldflags "-s -w -linkmode=external" -buildmode=c-shared \
       -o ../../build/aikido-request-processor.so
 
 RUN cc tools/dlopen-smoke.c -ldl -o /tmp/dlopen-smoke && \
     /tmp/dlopen-smoke build/aikido-request-processor.so && \
     file build/aikido-agent build/aikido-request-processor.so && \
-    /usr/local/go-pr/bin/go version && \
+    go version && \
     go version -m build/aikido-agent && \
     go version -m build/aikido-request-processor.so
 

--- a/.github/workflows/Dockerfile.package-alpine
+++ b/.github/workflows/Dockerfile.package-alpine
@@ -1,0 +1,48 @@
+# syntax=docker/dockerfile:1.7
+
+ARG ALPINE_VERSION=3.22
+
+FROM alpine:${ALPINE_VERSION} AS package-build
+
+ARG APK_ARCH
+ARG APK_OUTPUT=aikido-php-firewall.apk
+
+RUN apk add --no-cache alpine-sdk
+RUN adduser -D builder && \
+    addgroup builder abuild && \
+    mkdir -p /home/builder/package /home/builder/packages /out && \
+    chown -R builder:builder /home/builder
+
+WORKDIR /home/builder/package
+COPY --chown=builder:builder package/apk/APKBUILD ./APKBUILD
+COPY --chown=builder:builder package/apk/aikido-php-firewall.post-install ./
+COPY --chown=builder:builder package/apk/aikido-php-firewall.pre-deinstall ./
+COPY --chown=builder:builder package/rpm/opt/aikido/aikido.ini ./
+COPY --from=package-input --chown=builder:builder / ./
+
+RUN test "$(apk --print-arch)" = "${APK_ARCH}" && \
+    AIKIDO_VERSION="$(awk -F= '/^pkgver=/ { print $2 }' APKBUILD)" && \
+    sed -i "s/__VERSION__/${AIKIDO_VERSION}/g" \
+      aikido-php-firewall.post-install \
+      aikido-php-firewall.pre-deinstall
+
+USER builder
+RUN abuild-keygen -a -n
+
+USER root
+RUN cp /home/builder/.abuild/*.rsa.pub /etc/apk/keys/
+
+USER builder
+RUN abuild checksum && \
+    abuild -r
+
+USER root
+RUN APK_FILE="$(find /home/builder/packages -type f -name 'aikido-php-firewall-*.apk' | head -n 1)" && \
+    test -n "${APK_FILE}" && \
+    cp "${APK_FILE}" "/out/${APK_OUTPUT}" && \
+    apk verify --allow-untrusted "/out/${APK_OUTPUT}" && \
+    tar -tzf "/out/${APK_OUTPUT}" >/dev/null
+
+FROM scratch AS artifact
+ARG APK_OUTPUT=aikido-php-firewall.apk
+COPY --from=package-build /out/${APK_OUTPUT} /

--- a/.github/workflows/build-alpine.yml
+++ b/.github/workflows/build-alpine.yml
@@ -1,0 +1,198 @@
+name: Build Alpine
+
+on:
+  push:
+    branches:
+      - main
+  pull_request:
+    branches:
+      - main
+  workflow_call:
+
+permissions:
+  contents: read
+
+env:
+  ZEN_INTERNALS_VERSION: 0.1.64
+
+jobs:
+  build_libs:
+    name: Go libs (${{ matrix.package_arch }})
+    runs-on: ${{ matrix.runner }}
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - runner: ubuntu-24.04
+            package_arch: x86_64
+          - runner: ubuntu-24.04-arm
+            package_arch: aarch64
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4
+
+      - name: Build and test musl Go libraries
+        run: |
+          docker build \
+            --file .github/workflows/Dockerfile.build-libs-alpine \
+            --target artifacts \
+            --output type=local,dest=out \
+            .
+
+      - name: Archive musl Go libraries
+        uses: actions/upload-artifact@65c4c4a1ddee5b72f698fdd19549f0f0fb45cf08 # v4
+        with:
+          name: aikido-alpine-libs-${{ matrix.package_arch }}
+          if-no-files-found: error
+          path: |
+            out/aikido-agent
+            out/aikido-request-processor.so
+
+  build_extension:
+    name: PHP ${{ matrix.php_version }} ${{ matrix.zts == 1 && 'ZTS' || 'NTS' }} (${{ matrix.package_arch }})
+    runs-on: ${{ matrix.runner }}
+    strategy:
+      fail-fast: false
+      matrix:
+        php_version: ['8.2', '8.3', '8.4', '8.5']
+        zts: [0, 1]
+        package_arch: [x86_64, aarch64]
+        include:
+          - package_arch: x86_64
+            runner: ubuntu-24.04
+          - package_arch: aarch64
+            runner: ubuntu-24.04-arm
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4
+
+      - name: Select extension ABI
+        run: |
+          if [ "${{ matrix.zts }}" = "1" ]; then
+            echo "EXTENSION_ABI=zts" >> "$GITHUB_ENV"
+          else
+            echo "EXTENSION_ABI=nts" >> "$GITHUB_ENV"
+          fi
+
+      - name: Build and load extension
+        run: |
+          docker build \
+            --file .github/workflows/Dockerfile.build-extension-alpine \
+            --target artifact \
+            --build-arg PHP_VERSION=${{ matrix.php_version }} \
+            --build-arg PHP_ZTS=${{ matrix.zts }} \
+            --output type=local,dest=out \
+            .
+          mv out/aikido.so \
+            "out/aikido-extension-php-${{ matrix.php_version }}-${EXTENSION_ABI}.so"
+
+      - name: Archive extension
+        uses: actions/upload-artifact@65c4c4a1ddee5b72f698fdd19549f0f0fb45cf08 # v4
+        with:
+          name: aikido-alpine-extension-${{ matrix.php_version }}-${{ env.EXTENSION_ABI }}-${{ matrix.package_arch }}
+          if-no-files-found: error
+          path: out/aikido-extension-php-${{ matrix.php_version }}-${{ env.EXTENSION_ABI }}.so
+
+  build_apk:
+    name: APK (${{ matrix.package_arch }})
+    needs: [build_libs, build_extension]
+    runs-on: ${{ matrix.runner }}
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - runner: ubuntu-24.04
+            package_arch: x86_64
+            zen_sha256: 913edc48bc95e551695a37a27eb1ad49061c49befbbcd527a1bf52397a2bd52a
+          - runner: ubuntu-24.04-arm
+            package_arch: aarch64
+            zen_sha256: d6c89db778a8a21056a865c484cdb44f3940faad3814e330f2f2bb0f358965c3
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4
+
+      - name: Download musl Go libraries
+        uses: actions/download-artifact@fa0a91b85d4f404e444e00e005971372dc801d16 # v4
+        with:
+          name: aikido-alpine-libs-${{ matrix.package_arch }}
+          path: package-input
+
+      - name: Download PHP extensions
+        uses: actions/download-artifact@fa0a91b85d4f404e444e00e005971372dc801d16 # v4
+        with:
+          pattern: aikido-alpine-extension-*-${{ matrix.package_arch }}
+          merge-multiple: true
+          path: package-input
+
+      - name: Download and verify musl Zen Internals
+        run: |
+          ZEN_FILE="libzen_internals_${{ matrix.package_arch }}-unknown-linux-musl.so"
+          curl --fail --location --retry 3 \
+            --output package-input/libzen-internals.so \
+            "https://github.com/AikidoSec/zen-internals/releases/download/v${ZEN_INTERNALS_VERSION}/${ZEN_FILE}"
+          echo "${{ matrix.zen_sha256 }}  package-input/libzen-internals.so" | sha256sum -c -
+
+      - name: Build APK
+        run: |
+          APK_NAME="aikido-php-firewall.${{ matrix.package_arch }}.apk"
+          echo "APK_NAME=${APK_NAME}" >> "$GITHUB_ENV"
+          docker build \
+            --file .github/workflows/Dockerfile.package-alpine \
+            --build-context package-input=package-input \
+            --target artifact \
+            --build-arg APK_ARCH=${{ matrix.package_arch }} \
+            --build-arg APK_OUTPUT=${APK_NAME} \
+            --output type=local,dest=out \
+            .
+
+      - name: Install and load APK in Alpine PHP
+        run: |
+          AIKIDO_VERSION=$(awk -F= '/^pkgver=/ { print $2 }' package/apk/APKBUILD)
+          for PHP_IMAGE in php:8.4-cli-alpine3.22 php:8.4-zts-alpine3.22; do
+            docker run --rm \
+              -e AIKIDO_VERSION="${AIKIDO_VERSION}" \
+              -e AIKIDO_LOG_LEVEL=DEBUG \
+              -v "${PWD}/out/${APK_NAME}:/tmp/firewall.apk:ro" \
+              "${PHP_IMAGE}" sh -ec '
+                apk add --allow-untrusted /tmp/firewall.apk
+                php -m | grep -qx aikido
+                php -r "echo 1;" 2>&1 | tee /tmp/aikido.log
+                grep -q "Init data:" /tmp/aikido.log
+                test -x "/opt/aikido-${AIKIDO_VERSION}/aikido-agent"
+                test -f "/opt/aikido-${AIKIDO_VERSION}/aikido-request-processor.so"
+                test -f "/opt/aikido-${AIKIDO_VERSION}/libzen_internals_$(uname -m)-unknown-linux-musl.so"
+                find /usr/local/lib/php/extensions -name "aikido-${AIKIDO_VERSION}.so" -type l | grep -q .
+                apk del aikido-php-firewall
+                ! find /usr/local/lib/php/extensions -name "aikido-${AIKIDO_VERSION}.so" -type l | grep -q .
+                test ! -e "/usr/local/etc/php/conf.d/zz-aikido-${AIKIDO_VERSION}.ini"
+                test ! -e "/run/aikido-${AIKIDO_VERSION}"
+                test ! -e "/var/log/aikido-${AIKIDO_VERSION}"
+              '
+          done
+
+          docker run --rm \
+            -e AIKIDO_VERSION="${AIKIDO_VERSION}" \
+            -e AIKIDO_LOG_LEVEL=DEBUG \
+            -v "${PWD}/out/${APK_NAME}:/tmp/firewall.apk:ro" \
+            alpine:3.22 sh -ec '
+              apk add --no-cache php84
+              apk add --allow-untrusted /tmp/firewall.apk
+              php84 -m | grep -qx aikido
+              php84 -r "echo 1;" 2>&1 | tee /tmp/aikido.log
+              grep -q "Init data:" /tmp/aikido.log
+              test -L "/usr/lib/php84/modules/aikido-${AIKIDO_VERSION}.so"
+              test -L "/etc/php84/conf.d/zz-aikido-${AIKIDO_VERSION}.ini"
+              apk del aikido-php-firewall
+              test ! -e "/usr/lib/php84/modules/aikido-${AIKIDO_VERSION}.so"
+              test ! -e "/etc/php84/conf.d/zz-aikido-${AIKIDO_VERSION}.ini"
+            '
+
+      - name: Archive APK
+        uses: actions/upload-artifact@65c4c4a1ddee5b72f698fdd19549f0f0fb45cf08 # v4
+        with:
+          name: ${{ env.APK_NAME }}
+          if-no-files-found: error
+          path: out/${{ env.APK_NAME }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -29,15 +29,21 @@ jobs:
         check_version "$(awk -F'"' '/^[[:space:]]*Version[[:space:]]*=/ { print $2; exit }' lib/agent/constants/constants.go)" "lib/agent/constants/constants.go"
         check_version "$(awk -F'"' '/^[[:space:]]*Version[[:space:]]*=/ { print $2; exit }' lib/request-processor/globals/globals.go)" "lib/request-processor/globals/globals.go"
         check_version "$(awk '/^Version:/ { print $2 }' package/rpm/aikido.spec)" "package/rpm/aikido.spec"
+        check_version "$(awk -F= '/^pkgver=/ { print $2 }' package/apk/APKBUILD)" "package/apk/APKBUILD"
 
         exit "$FAILED"
 
   build:
     needs: validate_version
     uses: ./.github/workflows/build.yml
+
+  build_alpine:
+    needs: validate_version
+    uses: ./.github/workflows/build-alpine.yml
+
   release:
     runs-on: open-source-releaser
-    needs: build
+    needs: [build, build_alpine]
     permissions:
       contents: write
     steps:

--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,6 @@
 build
+package-input
+apk-out
 lib/php-extension/build
 lib/php-extension/autom4te.cache
 lib/php-extension/config.h.in

--- a/lib/request-processor/vulnerabilities/zen-internals/zen_internals.go
+++ b/lib/request-processor/vulnerabilities/zen-internals/zen_internals.go
@@ -3,7 +3,16 @@ package zen_internals
 /*
 #cgo LDFLAGS: -ldl
 #include <dlfcn.h>
+#include <features.h>
 #include <stdlib.h>
+
+const char* aikido_libc_variant() {
+#ifdef __GLIBC__
+    return "gnu";
+#else
+    return "musl";
+#endif
+}
 
 typedef int (*detect_sql_injection_func)(const char*, size_t, const char*, size_t, int);
 typedef int (*detect_shell_injection_func)(const char*, const char*);
@@ -35,8 +44,12 @@ type ZenInternalsLibrary struct {
 
 var zenLib = &ZenInternalsLibrary{}
 
+func getZenInternalsLibPath(version string, arch string, libcVariant string) string {
+	return fmt.Sprintf("/opt/aikido-%s/libzen_internals_%s-unknown-linux-%s.so", version, arch, libcVariant)
+}
+
 func Init() bool {
-	zenInternalsLibPath := C.CString(fmt.Sprintf("/opt/aikido-%s/libzen_internals_%s-unknown-linux-gnu.so", globals.Version, utils.GetArch()))
+	zenInternalsLibPath := C.CString(getZenInternalsLibPath(globals.Version, utils.GetArch(), C.GoString(C.aikido_libc_variant())))
 	defer C.free(unsafe.Pointer(zenInternalsLibPath))
 
 	handle := C.dlopen(zenInternalsLibPath, C.RTLD_LAZY)

--- a/lib/request-processor/vulnerabilities/zen-internals/zen_internals_test.go
+++ b/lib/request-processor/vulnerabilities/zen-internals/zen_internals_test.go
@@ -1,0 +1,20 @@
+package zen_internals
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestGetZenInternalsLibPath(t *testing.T) {
+	for _, libcVariant := range []string{"gnu", "musl"} {
+		t.Run(libcVariant, func(t *testing.T) {
+			assert.Equal(
+				t,
+				fmt.Sprintf("/opt/aikido-1.2.3/libzen_internals_x86_64-unknown-linux-%s.so", libcVariant),
+				getZenInternalsLibPath("1.2.3", "x86_64", libcVariant),
+			)
+		})
+	}
+}

--- a/package/apk/APKBUILD
+++ b/package/apk/APKBUILD
@@ -1,0 +1,55 @@
+# Maintainer: Aikido Security <support@aikido.dev>
+pkgname=aikido-php-firewall
+pkgver=1.5.21
+pkgrel=0
+pkgdesc="Aikido PHP Firewall"
+url="https://github.com/AikidoSec/firewall-php"
+arch="x86_64 aarch64"
+license="AGPL-3.0-or-later"
+# The runtime currently resolves its versioned binaries from /opt/aikido-*.
+options="!check !strip !fhs"
+install="$pkgname.post-install $pkgname.pre-deinstall"
+
+_php_versions="8.2 8.3 8.4 8.5"
+
+source="
+	aikido-agent
+	aikido-request-processor.so
+	libzen-internals.so
+	aikido.ini
+"
+
+for _php_version in $_php_versions; do
+	source="$source
+		aikido-extension-php-$_php_version-nts.so
+		aikido-extension-php-$_php_version-zts.so
+	"
+done
+
+package() {
+	local dest="$pkgdir/opt/aikido-$pkgver"
+	local zen_arch
+
+	case "$CARCH" in
+		x86_64) zen_arch=x86_64 ;;
+		aarch64) zen_arch=aarch64 ;;
+		*) die "Unsupported architecture: $CARCH" ;;
+	esac
+
+	install -Dm755 "$srcdir/aikido-agent" "$dest/aikido-agent"
+	install -Dm755 "$srcdir/aikido-request-processor.so" "$dest/aikido-request-processor.so"
+	install -Dm755 "$srcdir/libzen-internals.so" \
+		"$dest/libzen_internals_${zen_arch}-unknown-linux-musl.so"
+	install -Dm644 "$srcdir/aikido.ini" "$dest/aikido.ini"
+	sed -i "s/extension=aikido.so/extension=aikido-$pkgver.so/" "$dest/aikido.ini"
+
+	for _php_version in $_php_versions; do
+		install -Dm755 "$srcdir/aikido-extension-php-$_php_version-nts.so" \
+			"$dest/aikido-extension-php-$_php_version-nts.so"
+		install -Dm755 "$srcdir/aikido-extension-php-$_php_version-zts.so" \
+			"$dest/aikido-extension-php-$_php_version-zts.so"
+	done
+}
+
+# Populated from the generated build artifacts by `abuild checksum`.
+sha512sums=""

--- a/package/apk/aikido-php-firewall.post-install
+++ b/package/apk/aikido-php-firewall.post-install
@@ -1,0 +1,84 @@
+#!/bin/sh
+set -eu
+
+VERSION="__VERSION__"
+PAYLOAD_DIR="/opt/aikido-${VERSION}"
+FOUND_PHP=0
+
+echo "Configuring Aikido PHP Firewall v${VERSION}..."
+
+install -d -m 0777 "/var/log/aikido-${VERSION}" "/run/aikido-${VERSION}"
+
+PHP_BINS=""
+if command -v php >/dev/null 2>&1; then
+	PHP_BINS="$(command -v php)"
+fi
+
+for php_bin in /usr/bin/php /usr/local/bin/php /usr/bin/php[0-9]* /usr/local/bin/php[0-9]*; do
+	if [ -x "$php_bin" ]; then
+		case " $PHP_BINS " in
+			*" $php_bin "*) ;;
+			*) PHP_BINS="$PHP_BINS $php_bin" ;;
+		esac
+	fi
+done
+
+for php_bin in $PHP_BINS; do
+	php_version=$("$php_bin" -r 'echo PHP_MAJOR_VERSION . "." . PHP_MINOR_VERSION;' 2>/dev/null) || continue
+	extension_dir=$("$php_bin" -r 'echo ini_get("extension_dir");' 2>/dev/null) || continue
+	abi=$("$php_bin" -r 'echo PHP_ZTS ? "zts" : "nts";' 2>/dev/null) || continue
+	extension_file="$PAYLOAD_DIR/aikido-extension-php-${php_version}-${abi}.so"
+
+	if [ ! -f "$extension_file" ]; then
+		echo "Warning: no Aikido extension for PHP ${php_version} ${abi}; skipping ${php_bin}."
+		continue
+	fi
+
+	if [ ! -d "$extension_dir" ]; then
+		echo "Warning: extension directory ${extension_dir} does not exist; skipping ${php_bin}."
+		continue
+	fi
+
+	ln -sf "$extension_file" "$extension_dir/aikido-${VERSION}.so"
+
+	scan_dir=$("$php_bin" --ini 2>/dev/null | awk -F ': ' '/Scan for additional .ini files in/ { print $2; exit }')
+	case "$scan_dir" in
+		""|"(none)")
+			echo "Warning: ${php_bin} has no additional INI scan directory."
+			continue
+			;;
+	esac
+
+	mkdir -p "$scan_dir"
+	ln -sf "$PAYLOAD_DIR/aikido.ini" "$scan_dir/zz-aikido-${VERSION}.ini"
+	FOUND_PHP=1
+	echo "Configured ${php_bin} (PHP ${php_version}, ${abi})."
+done
+
+FRANKENPHP_BIN=""
+if command -v frankenphp >/dev/null 2>&1; then
+	FRANKENPHP_BIN=$(command -v frankenphp)
+elif [ -x /usr/local/bin/frankenphp ]; then
+	FRANKENPHP_BIN=/usr/local/bin/frankenphp
+elif [ -x /usr/bin/frankenphp ]; then
+	FRANKENPHP_BIN=/usr/bin/frankenphp
+fi
+
+if [ -n "$FRANKENPHP_BIN" ]; then
+	frankenphp_version=$("$FRANKENPHP_BIN" -v 2>/dev/null | sed -n 's/.*PHP \([0-9][0-9]*\.[0-9][0-9]*\).*/\1/p' | head -n 1)
+	frankenphp_extension="$PAYLOAD_DIR/aikido-extension-php-${frankenphp_version}-zts.so"
+	if [ -n "$frankenphp_version" ] && [ -f "$frankenphp_extension" ]; then
+		mkdir -p /usr/lib/frankenphp/modules /etc/frankenphp/php.d
+		ln -sf "$frankenphp_extension" "/usr/lib/frankenphp/modules/aikido-${VERSION}.so"
+		ln -sf "$PAYLOAD_DIR/aikido.ini" "/etc/frankenphp/php.d/zz-aikido-${VERSION}.ini"
+		FOUND_PHP=1
+		echo "Configured FrankenPHP (PHP ${frankenphp_version}, zts)."
+	fi
+fi
+
+if [ "$FOUND_PHP" -ne 1 ]; then
+	echo "No supported PHP installation was configured. Install PHP 8.2-8.5 before this package." >&2
+	exit 1
+fi
+
+echo "Aikido PHP Firewall v${VERSION} is configured."

--- a/package/apk/aikido-php-firewall.pre-deinstall
+++ b/package/apk/aikido-php-firewall.pre-deinstall
@@ -1,0 +1,41 @@
+#!/bin/sh
+set -eu
+
+VERSION="__VERSION__"
+
+echo "Removing Aikido PHP Firewall v${VERSION} configuration..."
+
+PHP_BINS=""
+if command -v php >/dev/null 2>&1; then
+	PHP_BINS="$(command -v php)"
+fi
+
+for php_bin in /usr/bin/php /usr/local/bin/php /usr/bin/php[0-9]* /usr/local/bin/php[0-9]*; do
+	if [ -x "$php_bin" ]; then
+		case " $PHP_BINS " in
+			*" $php_bin "*) ;;
+			*) PHP_BINS="$PHP_BINS $php_bin" ;;
+		esac
+	fi
+done
+
+for php_bin in $PHP_BINS; do
+	extension_dir=$("$php_bin" -r 'echo ini_get("extension_dir");' 2>/dev/null) || continue
+	scan_dir=$("$php_bin" --ini 2>/dev/null | awk -F ': ' '/Scan for additional .ini files in/ { print $2; exit }')
+	rm -f "$extension_dir/aikido-${VERSION}.so"
+	case "$scan_dir" in
+		""|"(none)") ;;
+		*) rm -f "$scan_dir/zz-aikido-${VERSION}.ini" ;;
+	esac
+done
+
+rm -f "/usr/lib/frankenphp/modules/aikido-${VERSION}.so"
+rm -f "/etc/frankenphp/php.d/zz-aikido-${VERSION}.ini"
+
+for pid in $(pidof aikido-agent 2>/dev/null || true); do
+	kill "$pid" 2>/dev/null || true
+done
+
+rm -rf "/var/log/aikido-${VERSION}" "/run/aikido-${VERSION}"
+
+echo "Aikido PHP Firewall v${VERSION} configuration was removed."

--- a/tools/dlopen-smoke.c
+++ b/tools/dlopen-smoke.c
@@ -1,0 +1,22 @@
+#include <dlfcn.h>
+#include <stdio.h>
+
+int main(int argc, char **argv) {
+    if (argc != 2) {
+        fprintf(stderr, "usage: %s <shared-library>\n", argv[0]);
+        return 2;
+    }
+
+    void *handle = dlopen(argv[1], RTLD_NOW | RTLD_LOCAL);
+    if (handle == NULL) {
+        fprintf(stderr, "dlopen failed: %s\n", dlerror());
+        return 1;
+    }
+
+    if (dlclose(handle) != 0) {
+        fprintf(stderr, "dlclose failed: %s\n", dlerror());
+        return 1;
+    }
+
+    return 0;
+}


### PR DESCRIPTION
## Summary

- add a dedicated Alpine/musl build for amd64 and arm64
- build every Alpine Go artifact and build tool with an exact pinned custom Go toolchain; checksum-pinned Go 1.26.7 is used only to bootstrap that compiler
- force external linking for Alpine Go tests and artifacts so the optional glibc probe remains a weak symbol on musl
- verify the c-shared request processor with a real musl `dlopen`
- build PHP 8.2-8.5 NTS/ZTS extensions and package the artifacts as an APK
- select the correct musl or glibc Zen Internals library at runtime
- include the Alpine build in releases

This is a replacement for #400, rebuilt from current `main`.

## Custom Go toolchain

The Alpine build temporarily depends on an unmerged Go runtime and linker change for loading C-shared libraries on musl. The builder pins the exact reviewed source commit instead of following a mutable branch. This should remain a draft while we review the risk of shipping an unmerged toolchain and collect CI evidence for both architectures.

The custom toolchain uses a weak reference to glibc's `gnu_get_libc_version` for runtime libc detection. In an ordinary cgo test executable, Go's default linker emits that reference as `GLOBAL UND`, so musl refuses to start the binary with `gnu_get_libc_version: symbol not found`. External linking preserves it as `WEAK UND`, as intended. The Alpine build therefore uses the custom compiler throughout and explicitly selects external linking for tests and shipped Go artifacts.

## Local validation

- GitHub workflow lint passed with actionlint v1.7.12
- APK lifecycle scripts passed `sh -n` on Alpine 3.22
- amd64 Alpine builder passed both Go test suites using the custom compiler and external linking
- the agent and request processor report the pinned custom Go version
- the agent and request processor are dynamically linked against musl
- the request processor passed a real `dlopen` smoke test under musl
- PHP 8.4 NTS extension compiled and loaded under Alpine

The arm64 build, full PHP NTS/ZTS matrix, APK build, and APK install/remove checks are delegated to this draft's CI.
