### PR TITLE
Allow Alpine jobs in release workflow

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -35,6 +35,7 @@ jobs:
 
   build:
     needs: validate_version
+    permissions: { actions: read, contents: read, packages: read }
     uses: ./.github/workflows/build.yml
   release:
     runs-on: open-source-releaser


### PR DESCRIPTION
## Summary

- allow the reusable build workflow to read Actions artifacts, repository contents, and GHCR packages
- prevent the Alpine test jobs from being rejected when invoked by the release workflow

## Context

The v1.5.22 tag run failed during workflow validation because the Alpine jobs request actions read access while the calling build job allowed none.

## Validation

- actionlint validation of release.yml
- git diff --check