### PR TITLE
Restrict GitHub release assets to packages

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -66,4 +66,6 @@ jobs:
       with:
         draft: true
         files: |
-          ./**/aikido-php-firewall*
+          ./**/aikido-php-firewall*.deb
+          ./**/aikido-php-firewall*.rpm
+          ./**/aikido-php-firewall*.apk


### PR DESCRIPTION
## Summary

- restrict GitHub release uploads to DEB, RPM, and APK files
- prevent Alpine lifecycle source scripts from being attached as standalone release assets

## Validation

- actionlint validation of release.yml
- git diff --check

The current v1.5.22 draft must still have its two accidental script assets removed manually; this change protects future releases.