### PR TITLE
Strip debug symbols from Alpine package

### DIFF
--- a/package/apk/APKBUILD
+++ b/package/apk/APKBUILD
@@ -7,7 +7,7 @@ url="https://github.com/AikidoSec/firewall-php"
 arch="x86_64 aarch64"
 license="AGPL-3.0-or-later"
 # The runtime currently resolves its versioned binaries from /opt/aikido-*.
-options="!check !strip !fhs"
+options="!check !fhs"
 install="$pkgname.post-install $pkgname.post-upgrade $pkgname.pre-deinstall"
 
 _php_versions="7.2 7.3 7.4 8.0 8.1 8.2 8.3 8.4 8.5"


### PR DESCRIPTION
## Summary

- allow Alpine's standard `abuild` stripping step to process the APK payload
- remove full compiler debug information from the PHP extensions
- reduce the x86_64 APK from 87.9 MB to 13.9 MB without changing its runtime layout

## Testing

- rebuilt the APK with `.github/workflows/Dockerfile.package-alpine`; `abuild` completed its stripping step
- inspected all 21 ELF files: no DWARF debug sections or symbol tables remain
- passed install, CLI/CGI load, and removal checks on Alpine 3.20, 3.21, 3.22, 3.23, and 3.24
- passed the full PHP 8.4 NTS CLI suite: 90 passed, 1 version-dependent skip, 0 failed
