### PR TITLE
Avoid false request processor errors when Aikido is disabled

### DIFF
--- a/lib/php-extension/RequestProcessor.cpp
+++ b/lib/php-extension/RequestProcessor.cpp
@@ -231,7 +231,6 @@ bool RequestProcessorInstance::RequestInit() {
         // the request processor is a go library that brings in the Go runtime, which (once initialized) 
         // can start threads, install signal handlers, set up GC, etc)
         if(!requestProcessor.Init()){
-            AIKIDO_LOG_ERROR("Failed to initialize Aikido Request Processor!\n");
             return false;
         } 
     

--- a/tests/cli/aikido_ops/test_disabled_request_processor_does_not_log_error.phpt
+++ b/tests/cli/aikido_ops/test_disabled_request_processor_does_not_log_error.phpt
@@ -1,0 +1,16 @@
+--TEST--
+Disabling Aikido does not log a request processor initialization error
+
+--ENV--
+AIKIDO_DISABLE=true
+AIKIDO_DEBUG=0
+AIKIDO_LOG_LEVEL=ERROR
+AIKIDO_DISK_LOGS=0
+
+--FILE--
+<?php
+echo "Request completed\n";
+?>
+
+--EXPECT--
+Request completed


### PR DESCRIPTION
With `AIKIDO_DISABLE=true`, intentionally skipped request-processor initialization produces a false error on every request. Remove the redundant caller log; `RequestProcessor::Init()` already reports genuine initialization failures itself.

Validation on PHP 8.5 NTS:
- The new PHPT fails on latest main with the reported error and passes with the one-line deletion.
- The existing extension-error-logging PHPT passes.
- Enabled initialization with a missing processor library still logs the specific library-loading failure.
- Native extension build, matching Go library build, and `git diff --check` pass.
