### PR TITLE
Prepare 1.5.25 release

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,25 +39,25 @@ Prerequisites:
 
 ##### x86_64
 ```
-rpm -Uvh --oldpackage https://github.com/AikidoSec/firewall-php/releases/download/v1.5.24/aikido-php-firewall.x86_64.rpm
+rpm -Uvh --oldpackage https://github.com/AikidoSec/firewall-php/releases/download/v1.5.25/aikido-php-firewall.x86_64.rpm
 ```
 
 ##### arm64 / aarch64
 ```
-rpm -Uvh --oldpackage https://github.com/AikidoSec/firewall-php/releases/download/v1.5.24/aikido-php-firewall.aarch64.rpm
+rpm -Uvh --oldpackage https://github.com/AikidoSec/firewall-php/releases/download/v1.5.25/aikido-php-firewall.aarch64.rpm
 ```
 
 #### For Debian-based Systems (Debian, Ubuntu)
 
 ##### x86_64
 ```
-curl -L -O https://github.com/AikidoSec/firewall-php/releases/download/v1.5.24/aikido-php-firewall.x86_64.deb
+curl -L -O https://github.com/AikidoSec/firewall-php/releases/download/v1.5.25/aikido-php-firewall.x86_64.deb
 dpkg -i -E ./aikido-php-firewall.x86_64.deb
 ```
 
 ##### arm64 / aarch64
 ```
-curl -L -O https://github.com/AikidoSec/firewall-php/releases/download/v1.5.24/aikido-php-firewall.aarch64.deb
+curl -L -O https://github.com/AikidoSec/firewall-php/releases/download/v1.5.25/aikido-php-firewall.aarch64.deb
 dpkg -i -E ./aikido-php-firewall.aarch64.deb
 ```
 
@@ -70,7 +70,7 @@ Alpine 3.20 or newer is supported. Download the APK matching your architecture:
 
 ```
 ARCH="$(uname -m)"
-curl -L -O "https://github.com/AikidoSec/firewall-php/releases/download/v1.5.24/aikido-php-firewall.${ARCH}.apk"
+curl -L -O "https://github.com/AikidoSec/firewall-php/releases/download/v1.5.25/aikido-php-firewall.${ARCH}.apk"
 apk add --allow-untrusted "./aikido-php-firewall.${ARCH}.apk"
 ```
 

--- a/docs/aws-elastic-beanstalk.md
+++ b/docs/aws-elastic-beanstalk.md
@@ -4,7 +4,7 @@
 ```
 commands:
   aikido-php-firewall:
-    command: "rpm -Uvh --oldpackage https://github.com/AikidoSec/firewall-php/releases/download/v1.5.24/aikido-php-firewall.x86_64.rpm"
+    command: "rpm -Uvh --oldpackage https://github.com/AikidoSec/firewall-php/releases/download/v1.5.25/aikido-php-firewall.x86_64.rpm"
     ignoreErrors: true
 
 files:

--- a/docs/fly-io.md
+++ b/docs/fly-io.md
@@ -32,7 +32,7 @@ Create a script to install the Aikido PHP Firewall during deployment:
 #!/usr/bin/env bash
 cd /tmp
 
-curl -L -O https://github.com/AikidoSec/firewall-php/releases/download/v1.5.24/aikido-php-firewall.x86_64.deb
+curl -L -O https://github.com/AikidoSec/firewall-php/releases/download/v1.5.25/aikido-php-firewall.x86_64.deb
 dpkg -i -E ./aikido-php-firewall.x86_64.deb
 ```
 

--- a/docs/laravel-forge.md
+++ b/docs/laravel-forge.md
@@ -8,7 +8,7 @@ You can get your token from the [Aikido Security Dashboard](https://help.aikido.
 
 Go to "Commands" and run the following by replacing the sudo password with the one that Forge displays when the server is created:
 ```
-curl -L -O https://github.com/AikidoSec/firewall-php/releases/download/v1.5.24/aikido-php-firewall.x86_64.deb && echo "YOUR_SUDO_PASSWORD_HERE" | sudo -S dpkg -i -E ./aikido-php-firewall.x86_64.deb && echo "YOUR_SUDO_PASSWORD_HERE" | sudo -S service php8.4-fpm restart
+curl -L -O https://github.com/AikidoSec/firewall-php/releases/download/v1.5.25/aikido-php-firewall.x86_64.deb && echo "YOUR_SUDO_PASSWORD_HERE" | sudo -S dpkg -i -E ./aikido-php-firewall.x86_64.deb && echo "YOUR_SUDO_PASSWORD_HERE" | sudo -S service php8.4-fpm restart
 ```
 
 ![Forge Commands](./forge-commands.png)

--- a/docs/laravel-octane-frankenphp.md
+++ b/docs/laravel-octane-frankenphp.md
@@ -8,7 +8,7 @@ You can get your token from the [Aikido Security Dashboard](https://help.aikido.
 
 `docker/version/Dockerfile`
 ```dockerfile
-ARG AIKIDO_VERSION=1.5.24
+ARG AIKIDO_VERSION=1.5.25
 
 RUN curl -L -o /tmp/aikido-php-firewall.deb \
     "https://github.com/AikidoSec/firewall-php/releases/download/v${AIKIDO_VERSION}/aikido-php-firewall.$(uname -m).deb" \
@@ -75,7 +75,7 @@ dpkg -i -E ./aikido-php-firewall.$(uname -m).deb
 ```dockerfile
 FROM dunglas/frankenphp:php${PHP_VERSION}-bookworm
 
-ARG AIKIDO_VERSION=1.5.24
+ARG AIKIDO_VERSION=1.5.25
 
 RUN apt-get update && apt-get install -y curl \
     && curl -L -o /tmp/aikido-php-firewall.deb \

--- a/lib/agent/constants/constants.go
+++ b/lib/agent/constants/constants.go
@@ -1,7 +1,7 @@
 package constants
 
 const (
-	Version                             = "1.5.24"
+	Version                             = "1.5.25"
 	RunPath                             = "/run/aikido-" + Version
 	SocketPath                          = RunPath + "/aikido-agent.sock"
 	ConfigUpdatedAtMethod               = "GET"

--- a/lib/php-extension/include/php_aikido.h
+++ b/lib/php-extension/include/php_aikido.h
@@ -19,7 +19,7 @@
 extern zend_module_entry aikido_module_entry;
 #define phpext_aikido_ptr &aikido_module_entry
 
-#define PHP_AIKIDO_VERSION "1.5.24"
+#define PHP_AIKIDO_VERSION "1.5.25"
 
 #if defined(ZTS) && defined(COMPILE_DL_AIKIDO)
 ZEND_TSRMLS_CACHE_EXTERN()

--- a/lib/request-processor/globals/globals.go
+++ b/lib/request-processor/globals/globals.go
@@ -79,6 +79,6 @@ func CreateServer(token string) *ServerData {
 }
 
 const (
-	Version    = "1.5.24"
+	Version    = "1.5.25"
 	SocketPath = "/run/aikido-" + Version + "/aikido-agent.sock"
 )

--- a/package/apk/APKBUILD
+++ b/package/apk/APKBUILD
@@ -1,6 +1,6 @@
 # Maintainer: Aikido Security <support@aikido.dev>
 pkgname=aikido-php-firewall
-pkgver=1.5.24
+pkgver=1.5.25
 pkgrel=0
 pkgdesc="Aikido PHP Firewall"
 url="https://github.com/AikidoSec/firewall-php"

--- a/package/rpm/aikido.spec
+++ b/package/rpm/aikido.spec
@@ -1,5 +1,5 @@
 Name:           aikido-php-firewall
-Version:        1.5.24
+Version:        1.5.25
 Release:        1
 Summary:        Aikido PHP Extension
 License:        GPL


### PR DESCRIPTION
Bumps the PHP extension, Go components, APK/RPM package metadata, and installation documentation from 1.5.24 to 1.5.25.

Validation: all five runtime/package version sources agree, all ten changed files contain only the version replacement, and `git diff --check` passes. Full builds and runtime tests have not been run locally for this version-only change.