### PR TITLE
Fix shared-site configuration isolation in FrankenPHP and PHP-FPM

### DIFF
--- a/lib/php-extension/Aikido.cpp
+++ b/lib/php-extension/Aikido.cpp
@@ -172,7 +172,6 @@ PHP_GINIT_FUNCTION(aikido) {
     aikido_globals->report_stats_interval_to_agent = 0;
     aikido_globals->currentRequestStart = std::chrono::high_resolution_clock::time_point{};
     aikido_globals->totalOverheadForCurrentRequest = 0;
-    aikido_globals->laravelEnvLoaded = false;
     aikido_globals->checkedAutoBlock = false;
     aikido_globals->checkedShouldBlockRequest = false;
     aikido_globals->checkedWhitelistRequest = false;
@@ -197,13 +196,13 @@ PHP_GINIT_FUNCTION(aikido) {
     new (&aikido_globals->eventCache) EventCache();
     new (&aikido_globals->phpLifecycle) PhpLifecycle();
     new (&aikido_globals->stats) std::unordered_map<std::string, SinkStats>();
-    new (&aikido_globals->laravelEnv) std::unordered_map<std::string, std::string>();
+    new (&aikido_globals->dotEnvCache) std::unordered_map<std::string, std::unordered_map<std::string, std::string>>();
 #endif
 }
 
 PHP_GSHUTDOWN_FUNCTION(aikido) {
 #ifdef ZTS
-    aikido_globals->laravelEnv.~unordered_map();
+    aikido_globals->dotEnvCache.~unordered_map();
     aikido_globals->phpLifecycle.~PhpLifecycle();
     aikido_globals->action.~Action();
     aikido_globals->requestProcessorInstance.~RequestProcessorInstance();

--- a/lib/php-extension/Environment.cpp
+++ b/lib/php-extension/Environment.cpp
@@ -36,14 +36,13 @@ std::string GetSystemEnvVariable(const std::string& env_key) {
 
 bool LoadDotEnvFile() {
     std::string docRoot = AIKIDO_GLOBAL(server).GetVar("DOCUMENT_ROOT");
-    auto& cache = AIKIDO_GLOBAL(dotEnvCache);
-    if (cache.find(docRoot) != cache.end()) {
+    if (AIKIDO_GLOBAL(dotEnvCache).find(docRoot) != AIKIDO_GLOBAL(dotEnvCache).end()) {
         return true;
     }
 
-    // Cache missing files too, so switching sites never rechecks a previously seen root.
-    // Adding or changing a .env file requires a worker restart.
-    auto& values = cache[docRoot];
+    // Try to load .env once per document root in this worker/thread.
+    // Cached results remain unchanged until the worker restarts.
+    AIKIDO_GLOBAL(dotEnvCache)[docRoot] = {};
     AIKIDO_LOG_DEBUG("Trying to load .env file, starting with DOCUMENT_ROOT: %s\n", docRoot.c_str());
     if (docRoot.empty()) {
         AIKIDO_LOG_DEBUG("DOCUMENT_ROOT is empty!\n");
@@ -91,7 +90,7 @@ bool LoadDotEnvFile() {
                      (value.front() == '\'' && value.back() == '\''))) {
                     value = value.substr(1, value.length() - 2);
                 }
-                values[key] = value;
+                AIKIDO_GLOBAL(dotEnvCache)[docRoot][key] = value;
             }
         }
     }

--- a/lib/php-extension/Environment.cpp
+++ b/lib/php-extension/Environment.cpp
@@ -34,10 +34,10 @@ std::string GetSystemEnvVariable(const std::string& env_key) {
 }
 
 
-bool LoadDotEnvFile() {
+void LoadDotEnvFile() {
     std::string docRoot = AIKIDO_GLOBAL(server).GetVar("DOCUMENT_ROOT");
     if (AIKIDO_GLOBAL(dotEnvCache).find(docRoot) != AIKIDO_GLOBAL(dotEnvCache).end()) {
-        return true;
+        return;
     }
 
     // Try to load .env once per document root in this worker/thread.
@@ -46,7 +46,7 @@ bool LoadDotEnvFile() {
     AIKIDO_LOG_DEBUG("Trying to load .env file, starting with DOCUMENT_ROOT: %s\n", docRoot.c_str());
     if (docRoot.empty()) {
         AIKIDO_LOG_DEBUG("DOCUMENT_ROOT is empty!\n");
-        return false;
+        return;
     }
     std::string dotEnvPath = docRoot + "/../.env";
     std::ifstream envFile(dotEnvPath);
@@ -59,7 +59,7 @@ bool LoadDotEnvFile() {
         envFile.open(dotEnvPath);
         if (!envFile.is_open()) {
             AIKIDO_LOG_DEBUG("Failed to open .env file: %s\n", dotEnvPath.c_str());
-            return false;
+            return;
         }
     }
     AIKIDO_LOG_DEBUG("Found .env file: %s\n", dotEnvPath.c_str());
@@ -95,7 +95,6 @@ bool LoadDotEnvFile() {
         }
     }
     AIKIDO_LOG_DEBUG("Loaded .env file: %s\n", dotEnvPath.c_str());
-    return true;
 }
 
 

--- a/lib/php-extension/Environment.cpp
+++ b/lib/php-extension/Environment.cpp
@@ -34,32 +34,36 @@ std::string GetSystemEnvVariable(const std::string& env_key) {
 }
 
 
-bool LoadLaravelEnvFile() {
-    if (AIKIDO_GLOBAL(laravelEnvLoaded)) {
+bool LoadDotEnvFile() {
+    std::string docRoot = AIKIDO_GLOBAL(server).GetVar("DOCUMENT_ROOT");
+    auto& cache = AIKIDO_GLOBAL(dotEnvCache);
+    if (cache.find(docRoot) != cache.end()) {
         return true;
     }
 
-    std::string docRoot = AIKIDO_GLOBAL(server).GetVar("DOCUMENT_ROOT");
+    // Cache missing files too, so switching sites never rechecks a previously seen root.
+    // Adding or changing a .env file requires a worker restart.
+    auto& values = cache[docRoot];
     AIKIDO_LOG_DEBUG("Trying to load .env file, starting with DOCUMENT_ROOT: %s\n", docRoot.c_str());
     if (docRoot.empty()) {
         AIKIDO_LOG_DEBUG("DOCUMENT_ROOT is empty!\n");
         return false;
     }
-    std::string laravelEnvPath = docRoot + "/../.env";
-    std::ifstream envFile(laravelEnvPath);
+    std::string dotEnvPath = docRoot + "/../.env";
+    std::ifstream envFile(dotEnvPath);
 
     if (!envFile.is_open()) {
-        AIKIDO_LOG_DEBUG("Failed to open .env file: %s\n", laravelEnvPath.c_str());
+        AIKIDO_LOG_DEBUG("Failed to open .env file: %s\n", dotEnvPath.c_str());
 
         // Try to open .env file from docRoot + "/.env" if not found at docRoot + "/../.env"
-        laravelEnvPath = docRoot + "/.env";
-        envFile.open(laravelEnvPath);
+        dotEnvPath = docRoot + "/.env";
+        envFile.open(dotEnvPath);
         if (!envFile.is_open()) {
-            AIKIDO_LOG_DEBUG("Failed to open .env file: %s\n", laravelEnvPath.c_str());
+            AIKIDO_LOG_DEBUG("Failed to open .env file: %s\n", dotEnvPath.c_str());
             return false;
         }
     }
-    AIKIDO_LOG_DEBUG("Found .env file: %s\n", laravelEnvPath.c_str());
+    AIKIDO_LOG_DEBUG("Found .env file: %s\n", dotEnvPath.c_str());
 
     std::string line;
     while (std::getline(envFile, line)) {
@@ -87,12 +91,11 @@ bool LoadLaravelEnvFile() {
                      (value.front() == '\'' && value.back() == '\''))) {
                     value = value.substr(1, value.length() - 2);
                 }
-                AIKIDO_GLOBAL(laravelEnv)[key] = value;
+                values[key] = value;
             }
         }
     }
-    AIKIDO_GLOBAL(laravelEnvLoaded) = true;
-    AIKIDO_LOG_DEBUG("Loaded Laravel env file: %s\n", laravelEnvPath.c_str());
+    AIKIDO_LOG_DEBUG("Loaded .env file: %s\n", dotEnvPath.c_str());
     return true;
 }
 
@@ -126,15 +129,20 @@ std::string GetFrankenEnvVariable(const std::string& env_key) {
     return env_value;
 }
 
-std::string GetLaravelEnvVariable(const std::string& env_key) {
-    const auto& laravelEnv = AIKIDO_GLOBAL(laravelEnv);
-    if (laravelEnv.find(env_key) != laravelEnv.end()) {
+std::string GetDotEnvVariable(const std::string& env_key) {
+    const auto& cache = AIKIDO_GLOBAL(dotEnvCache);
+    auto cached = cache.find(AIKIDO_GLOBAL(server).GetVar("DOCUMENT_ROOT"));
+    if (cached == cache.end()) {
+        return "";
+    }
+    const auto& dotEnv = cached->second;
+    if (dotEnv.find(env_key) != dotEnv.end()) {
         if (env_key == "AIKIDO_TOKEN") {
-            AIKIDO_LOG_DEBUG("laravel_env[%s] = %s\n", env_key.c_str(), AnonymizeToken(laravelEnv.at(env_key)).c_str());
+            AIKIDO_LOG_DEBUG("dotenv[%s] = %s\n", env_key.c_str(), AnonymizeToken(dotEnv.at(env_key)).c_str());
         } else {
-            AIKIDO_LOG_DEBUG("laravel_env[%s] = %s\n", env_key.c_str(), laravelEnv.at(env_key).c_str());
+            AIKIDO_LOG_DEBUG("dotenv[%s] = %s\n", env_key.c_str(), dotEnv.at(env_key).c_str());
         }
-        return laravelEnv.at(env_key);
+        return dotEnv.at(env_key);
     }
     return "";
 }
@@ -144,7 +152,7 @@ std::string GetLaravelEnvVariable(const std::string& env_key) {
     - System environment variables
     - FrankenPHP environment variables ($_SERVER - request-specific, thread-safe)
     - PHP environment variables 
-    - Laravel environment variables
+    - .env file variables
     
     Order is critical: In multithreaded environments (FrankenPHP worker/classic, ZTS),
     getenv() returns cached process-level values that may belong to a different request.
@@ -157,7 +165,7 @@ const std::vector<EnvGetterFn> completeEnvGetters = {
     &GetSystemEnvVariable,
     &GetFrankenEnvVariable,
     &GetPhpEnvVariable,
-    &GetLaravelEnvVariable
+    &GetDotEnvVariable
 };
 
 const std::vector<EnvGetterFn> systemEnvGetters = {
@@ -252,6 +260,7 @@ void LoadEnvironmentFromGetters(const std::vector<EnvGetterFn>& envGetters) {
 }
 
 void LoadEnvironment() {
+    LoadDotEnvFile();
     LoadEnvironmentFromGetters(completeEnvGetters);
 }
 

--- a/lib/php-extension/RequestProcessor.cpp
+++ b/lib/php-extension/RequestProcessor.cpp
@@ -75,7 +75,6 @@ bool RequestProcessor::Init() {
 }
 
 std::string RequestProcessor::GetInitData(const std::string& userProvidedToken) {
-    LoadLaravelEnvFile();
     LoadEnvironment();
 
     auto& globalToken = AIKIDO_GLOBAL(token);
@@ -211,15 +210,14 @@ bool RequestProcessorInstance::ReportStats() {
 bool RequestProcessorInstance::RequestInit() {
     std::string sapiName = sapi_module.name;
 
-    if (sapiName == "apache2handler" || sapiName == "frankenphp") {
-        // Apache-mod-php and FrankenPHP can serve multiple sites per process
+    if (sapiName == "apache2handler" || sapiName == "frankenphp" || sapiName == "fpm-fcgi") {
+        // These SAPIs can serve multiple sites per process.
         // We need to reload config each request to detect token changes
           this->LoadConfigFromEnvironment();
       } else {
-          // Server APIs that are not apache-mod-php/frankenphp (like php-fpm, cli-server, ...) 
-          //  can only serve one site per process, so the config should be loaded at the first request.
+          // Other SAPIs retain their config after the first token is loaded.
           // If the token is not set at the first request, we try to reload it until we get a valid token.
-          // The user can update .env file via zero downtime deployments after the PHP server is started.
+          // Cached .env files are checked again only after the worker restarts.
           if (AIKIDO_GLOBAL(token) == "") {
               AIKIDO_LOG_INFO("Loading Aikido config until we get a valid token for SAPI: %s...\n", AIKIDO_GLOBAL(sapi_name).c_str());
               this->LoadConfigFromEnvironment();
@@ -276,16 +274,14 @@ void RequestProcessorInstance::LoadConfig(const std::string& previousToken, cons
     if (requestProcessor.requestProcessorConfigUpdateFn == nullptr || this->requestProcessorInstance == nullptr) {
         return;
     }
-    if (currentToken.empty()) {
-        AIKIDO_LOG_INFO("Current token is empty, skipping config reload...!\n");
-        return;
-    }
     if (previousToken == currentToken) {
         AIKIDO_LOG_INFO("Token is the same as previous one, skipping config reload...\n");
         return;
     }
 
     AIKIDO_LOG_INFO("Reloading Aikido config...\n");
+    // Attribute accumulated stats to the old site before selecting the new one.
+    this->ReportStats();
     std::string initJson = requestProcessor.GetInitData(currentToken);
     requestProcessor.requestProcessorConfigUpdateFn(this->requestProcessorInstance, GoCreateString(initJson));
 }

--- a/lib/php-extension/include/Environment.h
+++ b/lib/php-extension/include/Environment.h
@@ -4,7 +4,7 @@ void LoadEnvironment();
 
 void LoadSystemEnvironment();
 
-bool LoadDotEnvFile();
+void LoadDotEnvFile();
 
 bool GetEnvBoolWithAllGetters(const std::string& env_key, bool default_value);
 

--- a/lib/php-extension/include/Environment.h
+++ b/lib/php-extension/include/Environment.h
@@ -4,7 +4,7 @@ void LoadEnvironment();
 
 void LoadSystemEnvironment();
 
-bool LoadLaravelEnvFile();
+bool LoadDotEnvFile();
 
 bool GetEnvBoolWithAllGetters(const std::string& env_key, bool default_value);
 

--- a/lib/php-extension/include/php_aikido.h
+++ b/lib/php-extension/include/php_aikido.h
@@ -40,7 +40,6 @@ bool uses_symfony_http_foundation; // If true, method override is supported usin
 unsigned int report_stats_interval_to_agent; // Report once every X requests the collected stats to Agent
 std::chrono::high_resolution_clock::time_point currentRequestStart;
 uint64_t totalOverheadForCurrentRequest;
-bool laravelEnvLoaded;
 // The checkedAutoBlock module global variable is used to check if auto_block_request function
 // has already been called, in order to avoid multiple calls to this function.
 // Accessed via AIKIDO_GLOBAL(checkedAutoBlock).
@@ -92,7 +91,7 @@ std::unordered_map<std::string, SinkStats> stats;
 RequestProcessorInstance requestProcessorInstance;
 Action action;
 PhpLifecycle phpLifecycle;
-std::unordered_map<std::string, std::string> laravelEnv;
+std::unordered_map<std::string, std::unordered_map<std::string, std::string>> dotEnvCache;
 ZEND_END_MODULE_GLOBALS(aikido)
 
 ZEND_EXTERN_MODULE_GLOBALS(aikido)

--- a/lib/request-processor/config/config.go
+++ b/lib/request-processor/config/config.go
@@ -35,9 +35,8 @@ func ReloadAikidoConfig(instance *instance.RequestProcessorInstance, conf *Aikid
 		return false
 	}
 
-	if err := log.SetLogLevel(conf.LogLevel); err != nil && conf.Token != "" {
-		return false
-	}
+	// Invalid logging config must not prevent switching to the site's server.
+	_ = log.SetLogLevel(conf.LogLevel)
 
 	if conf.Token == "" {
 		// A tokenless site must not retain the previous site's policy or reporting token.
@@ -46,10 +45,7 @@ func ReloadAikidoConfig(instance *instance.RequestProcessorInstance, conf *Aikid
 		return true
 	}
 
-	if !globals.ServerExists(conf.Token) {
-		server := globals.CreateServer(conf.Token)
-		server.AikidoConfig = *conf
-	}
+	globals.GetOrCreateServer(conf.Token, *conf)
 	if !UpdateToken(instance, conf.Token) {
 		return true
 	}
@@ -59,13 +55,17 @@ func ReloadAikidoConfig(instance *instance.RequestProcessorInstance, conf *Aikid
 }
 
 func initializeServer(server *ServerData) {
-	server.ServerInitMutex.Lock()
-	if !server.ServerInitialized {
-		grpc.SendAikidoConfig(server)
-		grpc.OnPackages(server, server.AikidoConfig.Packages)
-		server.ServerInitialized = true
-	}
-	server.ServerInitMutex.Unlock()
+	// Release the lock before GetCloudConfig because network calls can block.
+	func() {
+		server.ServerInitMutex.Lock()
+		defer server.ServerInitMutex.Unlock()
+
+		if !server.ServerInitialized {
+			grpc.SendAikidoConfig(server)
+			grpc.OnPackages(server, server.AikidoConfig.Packages)
+			server.ServerInitialized = true
+		}
+	}()
 	grpc.GetCloudConfig(server, 5*time.Second)
 }
 

--- a/lib/request-processor/config/config.go
+++ b/lib/request-processor/config/config.go
@@ -35,15 +35,15 @@ func ReloadAikidoConfig(instance *instance.RequestProcessorInstance, conf *Aikid
 		return false
 	}
 
-	if err := log.SetLogLevel(conf.LogLevel); err != nil {
-		return false
-	}
-
 	if conf.Token == "" {
 		// A tokenless site must not retain the previous site's policy or reporting token.
 		instance.SetCurrentToken("")
 		instance.SetCurrentServer(nil)
 		return true
+	}
+
+	if err := log.SetLogLevel(conf.LogLevel); err != nil {
+		return false
 	}
 
 	if !globals.ServerExists(conf.Token) {
@@ -60,12 +60,12 @@ func ReloadAikidoConfig(instance *instance.RequestProcessorInstance, conf *Aikid
 
 func initializeServer(server *ServerData) {
 	server.ServerInitMutex.Lock()
-	defer server.ServerInitMutex.Unlock()
 	if !server.ServerInitialized {
 		grpc.SendAikidoConfig(server)
 		grpc.OnPackages(server, server.AikidoConfig.Packages)
 		server.ServerInitialized = true
 	}
+	server.ServerInitMutex.Unlock()
 	grpc.GetCloudConfig(server, 5*time.Second)
 }
 

--- a/lib/request-processor/config/config.go
+++ b/lib/request-processor/config/config.go
@@ -35,15 +35,15 @@ func ReloadAikidoConfig(instance *instance.RequestProcessorInstance, conf *Aikid
 		return false
 	}
 
+	if err := log.SetLogLevel(conf.LogLevel); err != nil && conf.Token != "" {
+		return false
+	}
+
 	if conf.Token == "" {
 		// A tokenless site must not retain the previous site's policy or reporting token.
 		instance.SetCurrentToken("")
 		instance.SetCurrentServer(nil)
 		return true
-	}
-
-	if err := log.SetLogLevel(conf.LogLevel); err != nil {
-		return false
 	}
 
 	if !globals.ServerExists(conf.Token) {

--- a/lib/request-processor/config/config.go
+++ b/lib/request-processor/config/config.go
@@ -4,10 +4,12 @@ import (
 	"encoding/json"
 	. "main/aikido_types"
 	"main/globals"
+	"main/grpc"
 	"main/instance"
 	"main/log"
 	"main/utils"
 	"os"
+	"time"
 )
 
 func UpdateToken(instance *instance.RequestProcessorInstance, token string) bool {
@@ -27,39 +29,44 @@ func UpdateToken(instance *instance.RequestProcessorInstance, token string) bool
 	return true
 }
 
-type ReloadResult int
-
-const (
-	ReloadError ReloadResult = iota
-	ReloadWithSameToken
-	ReloadWithNewToken
-	ReloadWithPastSeenToken
-)
-
-func ReloadAikidoConfig(instance *instance.RequestProcessorInstance, conf *AikidoConfigData, initJson string) ReloadResult {
+func ReloadAikidoConfig(instance *instance.RequestProcessorInstance, conf *AikidoConfigData, initJson string) bool {
 	err := json.Unmarshal([]byte(initJson), conf)
 	if err != nil {
-		return ReloadError
+		return false
 	}
 
 	if err := log.SetLogLevel(conf.LogLevel); err != nil {
-		return ReloadError
+		return false
 	}
 
 	if conf.Token == "" {
-		return ReloadError
+		// A tokenless site must not retain the previous site's policy or reporting token.
+		instance.SetCurrentToken("")
+		instance.SetCurrentServer(nil)
+		return true
 	}
 
-	if globals.ServerExists(conf.Token) {
-		if !UpdateToken(instance, conf.Token) {
-			return ReloadWithSameToken
-		}
-		return ReloadWithPastSeenToken
+	if !globals.ServerExists(conf.Token) {
+		server := globals.CreateServer(conf.Token)
+		server.AikidoConfig = *conf
 	}
-	server := globals.CreateServer(conf.Token)
-	server.AikidoConfig = *conf
-	UpdateToken(instance, conf.Token)
-	return ReloadWithNewToken
+	if !UpdateToken(instance, conf.Token) {
+		return true
+	}
+
+	initializeServer(instance.GetCurrentServer())
+	return true
+}
+
+func initializeServer(server *ServerData) {
+	server.ServerInitMutex.Lock()
+	defer server.ServerInitMutex.Unlock()
+	if !server.ServerInitialized {
+		grpc.SendAikidoConfig(server)
+		grpc.OnPackages(server, server.AikidoConfig.Packages)
+		server.ServerInitialized = true
+	}
+	grpc.GetCloudConfig(server, 5*time.Second)
 }
 
 func Init(platformName string, serverPID int32) {

--- a/lib/request-processor/config/config_test.go
+++ b/lib/request-processor/config/config_test.go
@@ -29,11 +29,22 @@ func TestReloadClearsTokenlessSiteAndRestoresCachedServer(t *testing.T) {
 
 	processor := instance.NewRequestProcessorInstance(1)
 	var siteA *aikido_types.ServerData
-	for _, token := range []string{"site-a", "site-a", "site-b", "", "", "site-a"} {
-		configJson := `{"token":"` + token + `","log_level":"WARN"}`
+	for _, testCase := range []struct{ token, logLevel string }{
+		{"site-a", "WARN"},
+		{"site-a", "WARN"},
+		{"site-b", "WARN"},
+		{"", "WARN"},
+		{"", "WARN"},
+		{"site-a", "WARN"},
+		{"", "info"},
+		{"", "info"},
+		{"site-a", "WARN"},
+	} {
+		token := testCase.token
+		configJson := `{"token":"` + token + `","log_level":"` + testCase.logLevel + `"}`
 		conf := aikido_types.AikidoConfigData{}
 		if !ReloadAikidoConfig(processor, &conf, configJson) {
-			t.Fatalf("token %q: reload failed", token)
+			t.Fatalf("token %q, log level %q: reload failed", token, testCase.logLevel)
 		}
 		if processor.GetCurrentToken() != token {
 			t.Fatalf("token %q: retained token %q", token, processor.GetCurrentToken())

--- a/lib/request-processor/config/config_test.go
+++ b/lib/request-processor/config/config_test.go
@@ -1,7 +1,9 @@
 package config
 
 import (
+	"main/aikido_types"
 	"main/globals"
+	"main/instance"
 	"testing"
 )
 
@@ -17,5 +19,38 @@ func TestInitUsesServerPIDFromExtension(t *testing.T) {
 
 	if globals.EnvironmentConfig.ServerPID != serverPID {
 		t.Fatalf("ServerPID = %d, expected %d", globals.EnvironmentConfig.ServerPID, serverPID)
+	}
+}
+
+func TestReloadClearsTokenlessSiteAndRestoresCachedServer(t *testing.T) {
+	previousServers := globals.Servers
+	globals.Servers = make(map[string]*aikido_types.ServerData)
+	t.Cleanup(func() { globals.Servers = previousServers })
+
+	processor := instance.NewRequestProcessorInstance(1)
+	var siteA *aikido_types.ServerData
+	for _, token := range []string{"site-a", "site-a", "site-b", "", "", "site-a"} {
+		configJson := `{"token":"` + token + `","log_level":"WARN"}`
+		conf := aikido_types.AikidoConfigData{}
+		if !ReloadAikidoConfig(processor, &conf, configJson) {
+			t.Fatalf("token %q: reload failed", token)
+		}
+		if processor.GetCurrentToken() != token {
+			t.Fatalf("token %q: retained token %q", token, processor.GetCurrentToken())
+		}
+		server := processor.GetCurrentServer()
+		if token == "" {
+			if server != nil || processor.IsInitialized() {
+				t.Fatal("tokenless site retained the previous server")
+			}
+		} else if server == nil || server.AikidoConfig.Token != token {
+			t.Fatalf("token %q: selected the wrong server", token)
+		}
+		if token == "site-a" {
+			if siteA != nil && server != siteA {
+				t.Fatal("returning to site A did not reuse its cached server")
+			}
+			siteA = server
+		}
 	}
 }

--- a/lib/request-processor/config/config_test.go
+++ b/lib/request-processor/config/config_test.go
@@ -4,6 +4,7 @@ import (
 	"main/aikido_types"
 	"main/globals"
 	"main/instance"
+	"sync"
 	"testing"
 )
 
@@ -39,6 +40,7 @@ func TestReloadClearsTokenlessSiteAndRestoresCachedServer(t *testing.T) {
 		{"", "info"},
 		{"", "info"},
 		{"site-a", "WARN"},
+		{"site-c", "info"},
 	} {
 		token := testCase.token
 		configJson := `{"token":"` + token + `","log_level":"` + testCase.logLevel + `"}`
@@ -66,5 +68,39 @@ func TestReloadClearsTokenlessSiteAndRestoresCachedServer(t *testing.T) {
 			}
 			siteA = server
 		}
+	}
+}
+
+func TestConcurrentReloadUsesOneServerPerToken(t *testing.T) {
+	previousServers := globals.Servers
+	globals.Servers = make(map[string]*aikido_types.ServerData)
+	t.Cleanup(func() { globals.Servers = previousServers })
+
+	const workers = 64
+	servers := make(chan *aikido_types.ServerData, workers)
+	var ready sync.WaitGroup
+	ready.Add(workers)
+
+	globals.ServersMutex.Lock()
+	for i := 0; i < workers; i++ {
+		go func(threadID uint64) {
+			ready.Done()
+			processor := instance.NewRequestProcessorInstance(threadID)
+			conf := aikido_types.AikidoConfigData{}
+			ReloadAikidoConfig(processor, &conf, `{"token":"shared-site","log_level":"WARN"}`)
+			servers <- processor.GetCurrentServer()
+		}(uint64(i + 1))
+	}
+	ready.Wait()
+	globals.ServersMutex.Unlock()
+
+	expected := <-servers
+	for i := 1; i < workers; i++ {
+		if server := <-servers; server != expected {
+			t.Errorf("processor selected server %p, expected %p", server, expected)
+		}
+	}
+	if server := globals.GetServer("shared-site"); server != expected {
+		t.Fatalf("stored server %p, expected %p", server, expected)
 	}
 }

--- a/lib/request-processor/config/config_test.go
+++ b/lib/request-processor/config/config_test.go
@@ -33,8 +33,8 @@ func TestReloadClearsTokenlessSiteAndRestoresCachedServer(t *testing.T) {
 		{"site-a", "WARN"},
 		{"site-a", "WARN"},
 		{"site-b", "WARN"},
-		{"", "WARN"},
-		{"", "WARN"},
+		{"", "INFO"},
+		{"", "INFO"},
 		{"site-a", "WARN"},
 		{"", "info"},
 		{"", "info"},
@@ -45,6 +45,9 @@ func TestReloadClearsTokenlessSiteAndRestoresCachedServer(t *testing.T) {
 		conf := aikido_types.AikidoConfigData{}
 		if !ReloadAikidoConfig(processor, &conf, configJson) {
 			t.Fatalf("token %q, log level %q: reload failed", token, testCase.logLevel)
+		}
+		if testCase.logLevel == "INFO" && globals.CurrentLogLevel != globals.LogInfoLevel {
+			t.Fatal("valid log level was ignored for tokenless config")
 		}
 		if processor.GetCurrentToken() != token {
 			t.Fatalf("token %q: retained token %q", token, processor.GetCurrentToken())

--- a/lib/request-processor/globals/globals.go
+++ b/lib/request-processor/globals/globals.go
@@ -64,18 +64,18 @@ func GetServers() []*ServerData {
 	return servers
 }
 
-func ServerExists(token string) bool {
-	ServersMutex.RLock()
-	defer ServersMutex.RUnlock()
-	_, exists := Servers[token]
-	return exists
-}
-
-func CreateServer(token string) *ServerData {
+func GetOrCreateServer(token string, aikidoConfig AikidoConfigData) *ServerData {
 	ServersMutex.Lock()
 	defer ServersMutex.Unlock()
-	Servers[token] = NewServerData()
-	return Servers[token]
+
+	if server, exists := Servers[token]; exists {
+		return server
+	}
+
+	server := NewServerData()
+	server.AikidoConfig = aikidoConfig
+	Servers[token] = server
+	return server
 }
 
 const (

--- a/lib/request-processor/grpc/config.go
+++ b/lib/request-processor/grpc/config.go
@@ -91,6 +91,10 @@ func setCloudConfig(server *ServerData, cloudConfigFromAgent *protos.CloudConfig
 	server.CloudConfigMutex.Lock()
 	defer server.CloudConfigMutex.Unlock()
 
+	if cloudConfigFromAgent.ConfigUpdatedAt <= server.CloudConfig.ConfigUpdatedAt {
+		return
+	}
+
 	server.CloudConfig.ConfigUpdatedAt = cloudConfigFromAgent.ConfigUpdatedAt
 
 	server.CloudConfig.Endpoints = map[EndpointKey]EndpointData{}

--- a/lib/request-processor/grpc/config_test.go
+++ b/lib/request-processor/grpc/config_test.go
@@ -1,0 +1,24 @@
+package grpc
+
+import (
+	"main/globals"
+	"main/ipc/protos"
+	"testing"
+)
+
+func TestSetCloudConfigIgnoresOlderOrRepeatedVersions(t *testing.T) {
+	server := globals.NewServerData()
+	setCloudConfig(server, &protos.CloudConfig{ConfigUpdatedAt: 2, Block: true})
+
+	for _, version := range []int64{1, 2} {
+		setCloudConfig(server, &protos.CloudConfig{ConfigUpdatedAt: version, Block: false})
+		if server.CloudConfig.ConfigUpdatedAt != 2 || server.CloudConfig.Block != 1 {
+			t.Fatalf("version %d replaced the current blocking policy", version)
+		}
+	}
+
+	setCloudConfig(server, &protos.CloudConfig{ConfigUpdatedAt: 3, Block: false})
+	if server.CloudConfig.ConfigUpdatedAt != 3 || server.CloudConfig.Block != 0 {
+		t.Fatal("newer cloud config was not applied")
+	}
+}

--- a/lib/request-processor/main.go
+++ b/lib/request-processor/main.go
@@ -13,7 +13,6 @@ import (
 	"main/utils"
 	zen_internals "main/vulnerabilities/zen-internals"
 	"strings"
-	"time"
 	"unsafe"
 )
 
@@ -36,12 +35,6 @@ var eventHandlers = map[int]HandlerFunction{
 	C.EVENT_PRE_SQL_QUERY_EXECUTED:   OnPreSqlQueryExecuted,
 }
 
-func initializeServer(server *ServerData) {
-	grpc.SendAikidoConfig(server)
-	grpc.OnPackages(server, server.AikidoConfig.Packages)
-	grpc.GetCloudConfig(server, 5*time.Second)
-}
-
 //export CreateInstance
 func CreateInstance(threadID uint64) unsafe.Pointer {
 	return instance.CreateInstance(threadID)
@@ -59,18 +52,6 @@ func InitInstance(instancePtr unsafe.Pointer, initJson string) bool {
 	log.Debugf(instanceObject, "Init data: %s", initJson)
 	log.Debugf(instanceObject, "Started with token: \"AIK_RUNTIME_***%s\"", utils.AnonymizeToken(instanceObject.GetCurrentToken()))
 
-	if globals.EnvironmentConfig.PlatformName != "cli" {
-		server := instanceObject.GetCurrentServer()
-		if server != nil {
-			server.ServerInitMutex.Lock()
-			defer server.ServerInitMutex.Unlock()
-			if server.ServerInitialized {
-				return true
-			}
-			initializeServer(server)
-			server.ServerInitialized = true
-		}
-	}
 	return true
 }
 
@@ -173,27 +154,7 @@ func RequestProcessorConfigUpdate(instancePtr unsafe.Pointer, configJson string)
 
 	log.Debugf(instance, "Reloading Aikido config...")
 	conf := AikidoConfigData{}
-
-	reloadResult := config.ReloadAikidoConfig(instance, &conf, configJson)
-
-	server := instance.GetCurrentServer()
-
-	if server == nil {
-		return false
-	}
-	switch reloadResult {
-	case config.ReloadWithNewToken:
-		initializeServer(server)
-		return true
-	case config.ReloadWithPastSeenToken:
-		grpc.GetCloudConfig(server, 5*time.Second)
-		return true
-	case config.ReloadWithSameToken:
-		return true
-	case config.ReloadError:
-		return false
-	}
-	return false
+	return config.ReloadAikidoConfig(instance, &conf, configJson)
 }
 
 //export RequestProcessorOnEvent


### PR DESCRIPTION
When the same PHP worker or thread serves site A and then site B, the firewall can retain A's token or settings for B. This fixes shared-site configuration selection in FrankenPHP classic and PHP-FPM.

## Issues fixed

- **FrankenPHP classic shared sites:** the dotenv loader cached the first successfully loaded file for the entire PHP thread. A later site with a different document root could therefore use the first site's token and blocking settings. This affects ordinary PHP apps as well as frameworks such as Laravel.
- **PHP-FPM shared sites:** `fpm-fcgi` was excluded from per-request configuration reloads, even though a worker in a shared pool can serve multiple sites. Request-specific FastCGI settings and dotenv values now select the current site's configuration.
- **Tokenless sites and reporting:** switching to a site without a token clears the previous app's Go state, preventing use of its cloud policy or reporting token. Invalid log levels cannot prevent cleanup, and valid log levels still apply to tokenless apps and CLI scripts. Pending native statistics are flushed before switching tokens so they remain attributed to the previous app.
- **Concurrent cloud refreshes:** an older response could overwrite a newer policy. Cloud configuration now accepts only newer versions while holding the existing configuration lock.

## Implementation

Cache dotenv values by document root, including missing files, using framework-neutral names. Returning to a previously seen root does not reopen its dotenv file; adding or changing that file requires restarting the PHP worker. Request-specific overrides are still resolved, and Go app state remains keyed by Aikido token.

`ReloadAikidoConfig` performs app selection and invokes initialization/refresh work through a private helper. The initialization mutex protects first-time setup; cloud refresh runs outside it so concurrent switches do not queue behind another request's RPC timeout. Logging initialization remains in `InitInstance`.

## Validation

- Full request-processor Go suite passed. Simple regression tests cover tokenless cleanup, valid and invalid log levels, cached-state reuse, and rejection of older or repeated cloud-policy versions.
- Reproduced the four CLI logging failures on the previous commit and verified they pass with the correction on PHP 8.5.9 NTS and PHP 8.4.25 ZTS.
- Latest rebuilt Go processor passed 20 focused PHP-FPM/FrankenPHP classic requests covering tokenless sites with valid and invalid log levels. Earlier shared-site coverage passed 21 scenarios / 105 requests, including actual blocking, metadata attribution, and dotenv cache reuse.
- A local concurrency probe verified cached-token refreshes run concurrently while retaining the initialization lock around setup.

The updated CI matrix is running. The local QA images do not cover all CGI/PostgreSQL tests. FrankenPHP worker-helper mode was not exercised locally.