### PR TITLE
Test multi-site configurations in shared FrankenPHP workers

### DIFF
--- a/tests/server/test_worker_config_switch/a/.env
+++ b/tests/server/test_worker_config_switch/a/.env
@@ -1,0 +1,2 @@
+AIKIDO_TOKEN=worker-site-a
+AIKIDO_BLOCK=0

--- a/tests/server/test_worker_config_switch/b/.env
+++ b/tests/server/test_worker_config_switch/b/.env
@@ -1,0 +1,2 @@
+AIKIDO_TOKEN=worker-site-b
+AIKIDO_BLOCK=1

--- a/tests/server/test_worker_config_switch/c/.env
+++ b/tests/server/test_worker_config_switch/c/.env
@@ -1,0 +1,2 @@
+AIKIDO_TOKEN=worker-site-c
+AIKIDO_BLOCK=0

--- a/tests/server/test_worker_config_switch/env.json
+++ b/tests/server/test_worker_config_switch/env.json
@@ -1,0 +1,4 @@
+{
+    "AIKIDO_TOKEN": "",
+    "DOCUMENT_ROOT": "{http.request.header.X-Test-Root}"
+}

--- a/tests/server/test_worker_config_switch/index.php
+++ b/tests/server/test_worker_config_switch/index.php
@@ -1,0 +1,24 @@
+<?php
+
+if (empty($_SERVER['FRANKENPHP_WORKER'])) {
+    http_response_code(200);
+    echo json_encode(['skip' => 'Requires FrankenPHP worker mode']);
+    return;
+}
+
+// Globals persist between requests handled by the same worker.
+global $workerId;
+$workerId = $workerId ?? bin2hex(random_bytes(8));
+
+$blocked = false;
+try {
+    file_get_contents(__DIR__ . '/' . $_GET['path']);
+} catch (Throwable $e) {
+    if (strpos($e->getMessage(), 'Aikido firewall has blocked a path traversal attack') === false) {
+        throw $e;
+    }
+    $blocked = true;
+}
+http_response_code(200);
+header('Content-Type: application/json');
+echo json_encode(['worker' => $workerId, 'blocked' => $blocked]);

--- a/tests/server/test_worker_config_switch/start_config.json
+++ b/tests/server/test_worker_config_switch/start_config.json
@@ -1,0 +1,7 @@
+{
+    "success": true,
+    "serviceId": 1,
+    "heartbeatIntervalInMS": 600000,
+    "endpoints": [],
+    "receivedAnyStats": true
+}

--- a/tests/server/test_worker_config_switch/test.py
+++ b/tests/server/test_worker_config_switch/test.py
@@ -1,0 +1,29 @@
+from pathlib import Path
+from testlib import *
+
+
+def run_test():
+    workers = set()
+    root = Path(__file__).resolve().parent
+    for phase, (site, blocked) in enumerate([('a', False), ('b', True), ('c', False), ('none', False), ('a', False)]):
+        document_root = root if site == 'none' else root / site
+        response = php_server_get('/?path=../test_worker_config_switch/index.php',
+                                  headers={'X-Test-Root': str(document_root)})
+        assert_response_code_is(response, 200)
+        result = response.json()
+        if 'skip' in result:
+            print(f"Skipping: {result['skip']}")
+            return
+        assert result['blocked'] == blocked, f'Site {site}: {result}'
+        print(f"Site {site}: blocked={blocked}, worker={result['worker']}")
+        if phase < 3:
+            workers.add(result['worker'])
+            token = mock_server_get_token()
+            assert token == f'worker-site-{site}', f'Site {site}: reporting token was {token}'
+    # Three configured sites and two workers guarantee a cross-site switch.
+    assert len(workers) < 3, 'Each configured site was handled by a different worker'
+
+
+if __name__ == '__main__':
+    load_test_args()
+    run_test()


### PR DESCRIPTION
Add a FrankenPHP worker regression test for the shared-site configuration leak fixed in #481: later sites could inherit an earlier site's token and blocking settings.

The test switches between three `.env` configurations, a tokenless root, and the first site again. It checks blocking behavior and the initial reporting token for each configured site. Three configured sites on the existing two-worker runner guarantee a cross-site switch, and persistent worker IDs verify that reuse without depending on request scheduling. The test uses the existing runner unchanged and skips outside worker mode.

Validation on FrankenPHP 1.12.7 / PHP 8.4.25 ZTS:
- Current main passes all five requests.
- The pre-fix package fails when site B retains site A's non-blocking configuration.
- Passes alongside the existing `test_set_token` integration test.
- PHP built-in and FrankenPHP classic skip the worker-only assertions correctly.
- PHP lint, Python parsing, and `git diff --check` pass.

The full platform/PHP-version matrix remains for CI.
