### PR TITLE
Speed up tests by avoiding public DNS stalls

### DIFF
--- a/tests/cli/outgoing_request/test_curl.phpt
+++ b/tests/cli/outgoing_request/test_curl.phpt
@@ -13,9 +13,12 @@ AIKIDO_LOG_LEVEL=INFO
 
 --FILE--
 <?php
+// Test hostname logging without waiting for public DNS or remote servers.
 $ch1 = curl_init("https://example.com/");
 curl_setopt($ch1, CURLOPT_RETURNTRANSFER, true);
 curl_setopt($ch1, CURLOPT_TIMEOUT, 1);
+curl_setopt($ch1, CURLOPT_CONNECT_TO, ["::127.0.0.1:1"]);
+curl_setopt($ch1, CURLOPT_PROXY, "");
 curl_exec($ch1);
 curl_close($ch1);
 
@@ -28,6 +31,8 @@ $queryParams = http_build_query([
 curl_setopt($ch2, CURLOPT_RETURNTRANSFER, true);
 curl_setopt($ch2, CURLOPT_URL, "https://httpbin.org/get?" . $queryParams);
 curl_setopt($ch2, CURLOPT_TIMEOUT, 10);
+curl_setopt($ch2, CURLOPT_CONNECT_TO, ["::127.0.0.1:1"]);
+curl_setopt($ch2, CURLOPT_PROXY, "");
 curl_exec($ch2);
 curl_close($ch2);
 
@@ -39,24 +44,32 @@ CURLOPT_HEADER => false,
 CURLOPT_TIMEOUT => 1
 ];
 curl_setopt_array($ch3, $options);
+curl_setopt($ch3, CURLOPT_CONNECT_TO, ["::127.0.0.1:1"]);
+curl_setopt($ch3, CURLOPT_PROXY, "");
 curl_exec($ch3);
 curl_close($ch3);
 
 $ch4 = curl_init("https://facebook.com:443");
 curl_setopt($ch4, CURLOPT_RETURNTRANSFER, true);
 curl_setopt($ch4, CURLOPT_TIMEOUT, 1);
+curl_setopt($ch4, CURLOPT_CONNECT_TO, ["::127.0.0.1:1"]);
+curl_setopt($ch4, CURLOPT_PROXY, "");
 curl_exec($ch4);
 curl_close($ch4);
 
 $ch5 = curl_init("http://www.aikido.dev:80");
 curl_setopt($ch5, CURLOPT_RETURNTRANSFER, true);
 curl_setopt($ch5, CURLOPT_TIMEOUT, 1);
+curl_setopt($ch5, CURLOPT_CONNECT_TO, ["::127.0.0.1:1"]);
+curl_setopt($ch5, CURLOPT_PROXY, "");
 curl_exec($ch5);
 curl_close($ch5);
 
 $ch6 = curl_init("http://some-invalid-domain.com:4113");
 curl_setopt($ch6, CURLOPT_RETURNTRANSFER, true);
 curl_setopt($ch6, CURLOPT_TIMEOUT, 1);
+curl_setopt($ch6, CURLOPT_CONNECT_TO, ["::127.0.0.1:1"]);
+curl_setopt($ch6, CURLOPT_PROXY, "");
 curl_exec($ch6);
 curl_close($ch6);
 

--- a/tests/cli/outgoing_request/test_curl_share.phpt
+++ b/tests/cli/outgoing_request/test_curl_share.phpt
@@ -18,10 +18,13 @@ curl_share_setopt($sh, CURLSHOPT_SHARE, CURL_LOCK_DATA_COOKIE);
 curl_share_setopt($sh, CURLSHOPT_SHARE, CURL_LOCK_DATA_DNS);
 curl_share_setopt($sh, CURLSHOPT_SHARE, CURL_LOCK_DATA_SSL_SESSION);
 
+// Test hostname logging without waiting for public DNS or remote servers.
 $ch1 = curl_init("https://example.com/");
 curl_setopt($ch1, CURLOPT_RETURNTRANSFER, true);
 curl_setopt($ch1, CURLOPT_TIMEOUT, 1);
 curl_setopt($ch1, CURLOPT_SHARE, $sh);
+curl_setopt($ch1, CURLOPT_CONNECT_TO, ["::127.0.0.1:1"]);
+curl_setopt($ch1, CURLOPT_PROXY, "");
 curl_exec($ch1);
 
 $ch2 = curl_init("https://httpbin.org/get");
@@ -33,6 +36,8 @@ curl_setopt($ch2, CURLOPT_RETURNTRANSFER, true);
 curl_setopt($ch2, CURLOPT_URL, "https://httpbin.org/get?" . $queryParams);
 curl_setopt($ch2, CURLOPT_TIMEOUT, 10);
 curl_setopt($ch2, CURLOPT_SHARE, $sh);
+curl_setopt($ch2, CURLOPT_CONNECT_TO, ["::127.0.0.1:1"]);
+curl_setopt($ch2, CURLOPT_PROXY, "");
 curl_exec($ch2);
 
 $ch3 = curl_init();
@@ -44,24 +49,32 @@ $options = [
     CURLOPT_SHARE => $sh
 ];
 curl_setopt_array($ch3, $options);
+curl_setopt($ch3, CURLOPT_CONNECT_TO, ["::127.0.0.1:1"]);
+curl_setopt($ch3, CURLOPT_PROXY, "");
 curl_exec($ch3);
 
 $ch4 = curl_init("https://facebook.com:443");
 curl_setopt($ch4, CURLOPT_RETURNTRANSFER, true);
 curl_setopt($ch4, CURLOPT_TIMEOUT, 1);
 curl_setopt($ch4, CURLOPT_SHARE, $sh);
+curl_setopt($ch4, CURLOPT_CONNECT_TO, ["::127.0.0.1:1"]);
+curl_setopt($ch4, CURLOPT_PROXY, "");
 curl_exec($ch4);
 
 $ch5 = curl_init("http://www.aikido.dev:80");
 curl_setopt($ch5, CURLOPT_RETURNTRANSFER, true);
 curl_setopt($ch5, CURLOPT_TIMEOUT, 1);
 curl_setopt($ch5, CURLOPT_SHARE, $sh);
+curl_setopt($ch5, CURLOPT_CONNECT_TO, ["::127.0.0.1:1"]);
+curl_setopt($ch5, CURLOPT_PROXY, "");
 curl_exec($ch5);
 
 $ch6 = curl_init("http://some-invalid-domain.com:4113");
 curl_setopt($ch6, CURLOPT_RETURNTRANSFER, true);
 curl_setopt($ch6, CURLOPT_TIMEOUT, 1);
 curl_setopt($ch6, CURLOPT_SHARE, $sh);
+curl_setopt($ch6, CURLOPT_CONNECT_TO, ["::127.0.0.1:1"]);
+curl_setopt($ch6, CURLOPT_PROXY, "");
 curl_exec($ch6);
 
 ?>

--- a/tests/server/test_blocked_outbound_domains/index.php
+++ b/tests/server/test_blocked_outbound_domains/index.php
@@ -12,6 +12,9 @@ if (isset($data['url'])) {
         $ch = curl_init($data['url']);
         curl_setopt($ch, CURLOPT_RETURNTRANSFER, true);
         curl_setopt($ch, CURLOPT_TIMEOUT, 5);
+        // Preserve the URL for policy checks without contacting external domains.
+        curl_setopt($ch, CURLOPT_CONNECT_TO, ["::127.0.0.1:1"]);
+        curl_setopt($ch, CURLOPT_PROXY, "");
         $result = curl_exec($ch);
         $httpCode = curl_getinfo($ch, CURLINFO_HTTP_CODE);
         curl_close($ch);

--- a/tests/server/test_domains_limits/index.php
+++ b/tests/server/test_domains_limits/index.php
@@ -3,6 +3,9 @@
 $ch1 = curl_init("http://" . $_GET['domain'] . ".com/");
 curl_setopt($ch1, CURLOPT_RETURNTRANSFER, false);
 curl_setopt($ch1, CURLOPT_HEADER, false);
+// Test hostname retention without waiting for public DNS or remote servers.
+curl_setopt($ch1, CURLOPT_CONNECT_TO, ["::127.0.0.1:1"]);
+curl_setopt($ch1, CURLOPT_PROXY, "");
 curl_setopt($ch1, CURLOPT_TIMEOUT_MS, 1);
 curl_setopt($ch1, CURLOPT_CONNECTTIMEOUT_MS, 1);
 curl_exec($ch1);

--- a/tests/server/test_domains_limits/start_config.json
+++ b/tests/server/test_domains_limits/start_config.json
@@ -5,6 +5,6 @@
     "endpoints": [],
     "blockedUserIds": [],
     "allowedIPAddresses": [],
-    "receivedAnyStats": true,
+    "receivedAnyStats": false,
     "block": false
 }

--- a/tests/server/test_domains_limits/test.py
+++ b/tests/server/test_domains_limits/test.py
@@ -18,7 +18,9 @@ def run_test():
         response = php_server_get(f"/?domain={domain}")
         assert_response_code_is(response, 200)
     
-    mock_server_wait_for_new_events(310)
+    # Accept a heartbeat that arrived before polling started.
+    assert wait_until(lambda: len(mock_server_get_events()) >= 2, 70) is not None, \
+        "Timed out waiting for the hostname heartbeat"
     
     events = mock_server_get_events()
     assert_events_length_is(events, 2)


### PR DESCRIPTION
Hostname logging and outbound-domain policy tests can stall on public DNS despite short cURL timeouts. Route these fixtures' connections to loopback and disable proxies while preserving the original URLs and existing assertions.

Use the existing one-minute first heartbeat for the domain-limit test, replacing its five-minute schedule, and accept the expected heartbeat even if it arrived before polling began. The test still sends 2,100 hostnames and checks the 2,000-host cap and eviction behavior.

Validation:
- Both affected server tests passed with Docker networking disabled on Debian/FrankenPHP 8.4 and CentOS Stream 9/PHP 8.3 (built-in server).
- The domain-limit test completed in 80–81 seconds including startup. The outbound-domain policy test still takes about 320 seconds because its configuration-refresh waits remain.
- The applicable CLI tests passed offline on PHP 8.4 and 8.5 in under one second each.
- Local runtime validation used CI binaries from d5f8e1eb. The six test files are unchanged from that validated patch; this branch is based on current main.

Estimated time savings:
- About 17–18 minutes off end-to-end CI on runs affected by these timeouts, assuming the fix eliminates the stalled attempts. In the two inspected runs, CI took 48m05s and 45m44s, while every other job had finished by 30m59s and 27m56s respectively. Removing those delays would bring these runs back to roughly 28–31 minutes. Evidence: [main run](https://github.com/AikidoSec/firewall-php/actions/runs/34450335434), [previous PR run](https://github.com/AikidoSec/firewall-php/actions/runs/34466243501).
- Healthy runs may finish little or no sooner: the domain-limit test saves about four minutes, but it overlaps with other tests that can still determine when CI finishes. The end-to-end improvement is an estimate pending CI validation.